### PR TITLE
fix: Add plant selection menu to inspection tree of hydroponics basin.

### DIFF
--- a/BuildingInspectState.cs
+++ b/BuildingInspectState.cs
@@ -172,6 +172,15 @@ namespace RimWorldAccess
                 }
             }
 
+            // Check if building is a plant grower (hydroponics basin, etc.)
+            if (selectedBuilding is IPlantToGrowSettable plantGrower)
+            {
+                // Close building inspect and open plant selection menu
+                Close();
+                PlantSelectionMenuState.Open(plantGrower);
+                return;
+            }
+
             // If no recognized settings, announce
             TolkHelper.Speak($"{selectedBuilding.LabelCap} has no keyboard-accessible settings");
         }

--- a/InspectionInfoHelper.cs
+++ b/InspectionInfoHelper.cs
@@ -115,6 +115,10 @@ namespace RimWorldAccess
                 if (building is IStoreSettingsParent || building is Building_Storage)
                     categories.Add("Storage");
 
+                // Check for plant grower (hydroponics basin, growing zones, etc.)
+                if (building is IPlantToGrowSettable)
+                    categories.Add("Plant Selection");
+
                 // Check for power
                 var powerComp = building.TryGetComp<CompPowerTrader>();
                 if (powerComp != null)

--- a/InspectionTreeBuilder.cs
+++ b/InspectionTreeBuilder.cs
@@ -225,6 +225,7 @@ namespace RimWorldAccess
                        (category == "Bed Assignment" && building is Building_Bed) ||
                        (category == "Temperature" && building.TryGetComp<CompTempControl>() != null) ||
                        (category == "Storage" && building is IStoreSettingsParent) ||
+                       (category == "Plant Selection" && building is IPlantToGrowSettable) ||
                        BuildingComponentsHelper.GetDiscoverableComponents(building).Any(c => c.CategoryName == category && !c.IsReadOnly);
             }
 
@@ -291,6 +292,10 @@ namespace RimWorldAccess
                 {
                     StorageSettingsMenuState.Open(settings);
                 }
+            }
+            else if (category == "Plant Selection" && building is IPlantToGrowSettable plantGrower)
+            {
+                PlantSelectionMenuState.Open(plantGrower);
             }
             else
             {


### PR DESCRIPTION
# Summary
Adds the plant selection menu to the inspection panel for hydroponics basins. 
Should also cover modded plant-growing buildings (untested).

Fixes #4

## Testing
- Loaded a save with a hydroponics basin
- Selected a new plant; pawns cut the existing plant and planted the replacement
- Verified screen reader announces plant information correctly
