### PR TITLE
build: Make RimWorld install path configurable via GamePaths.props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /obj/
 /.claude/
 release/
+GamePaths.props

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,9 @@ RimWorld Access is a MelonLoader mod for RimWorld that adds comprehensive keyboa
 dotnet build
 ```
 
-The build process automatically copies the compiled DLL and required dependencies to `C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\` via a post-build target.
+The build process automatically copies the compiled DLL and required
+dependencies to a `Mods` directory inside the game's installation directory via a
+post-build target.
 
 **Deployed files:**
 - `rimworld_access.dll` - The mod
@@ -465,8 +467,7 @@ See `api_reference.md` in the mod directory for detailed namespace breakdown.
 
 ## Dependencies
 
-All references use absolute paths to the RimWorld installation at:
-`C:\Program Files (x86)\Steam\steamapps\common\RimWorld\`
+All references use absolute paths to the RimWorld installation.
 
 - **MelonLoader** - Mod loading framework (`MelonLoader\net6\MelonLoader.dll`)
 - **0Harmony** - Runtime patching library (`MelonLoader\net6\0Harmony.dll`)

--- a/GamePaths.props.template
+++ b/GamePaths.props.template
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- Set this to your RimWorld installation directory -->
+    <RimWorldDir>D:\SteamLibrary\steamapps\common\RimWorld</RimWorldDir>
+  </PropertyGroup>
+</Project>

--- a/contributing.md
+++ b/contributing.md
@@ -20,6 +20,15 @@ dotnet build
 
 This will compile the mod and automatically copy the DLL and dependencies to your RimWorld Mods folder via a post-build script.
 
+**Custom RimWorld Install Location:**
+
+The project defaults to the standard Steam install path (`C:\Program Files (x86)\Steam\steamapps\common\RimWorld`). If your RimWorld is installed elsewhere:
+
+1. Copy `GamePaths.props.template` to `GamePaths.props`
+2. Edit `GamePaths.props` and set `RimWorldDir` to your install path
+
+The `GamePaths.props` file is gitignored, so your local configuration won't affect the repository.
+
 ### Building a Release Package
 
 To create a release package:

--- a/rimworld_access.csproj
+++ b/rimworld_access.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- Import local path overrides if they exist -->
+  <Import Project="GamePaths.props" Condition="Exists('GamePaths.props')" />
+
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
+    <!-- Default RimWorld install path (override in GamePaths.props for custom locations) -->
+    <RimWorldDir Condition="'$(RimWorldDir)'==''">C:\Program Files (x86)\Steam\steamapps\common\RimWorld</RimWorldDir>
   </PropertyGroup>
 
   <!-- Embed audio files as resources -->
@@ -24,30 +29,30 @@
 <ItemGroup>
   <!-- MelonLoader References -->
   <Reference Include="MelonLoader">
-    <HintPath>C:\Program Files (x86)\Steam\steamapps\common\RimWorld\MelonLoader\net6\MelonLoader.dll</HintPath>
+    <HintPath>$(RimWorldDir)\MelonLoader\net6\MelonLoader.dll</HintPath>
   </Reference>
   <Reference Include="0Harmony">
-    <HintPath>C:\Program Files (x86)\Steam\steamapps\common\RimWorld\MelonLoader\net6\0Harmony.dll</HintPath>
+    <HintPath>$(RimWorldDir)\MelonLoader\net6\0Harmony.dll</HintPath>
   </Reference>
 
   <!-- Game and Unity Engine References (from the game's Managed folder) -->
   <Reference Include="Assembly-CSharp">
-    <HintPath>C:\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
+    <HintPath>$(RimWorldDir)\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
   </Reference>
   <Reference Include="UnityEngine.CoreModule">
-    <HintPath>C:\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    <HintPath>$(RimWorldDir)\RimWorldWin64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
   </Reference>
   <Reference Include="UnityEngine.IMGUIModule">
-    <HintPath>C:\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
+    <HintPath>$(RimWorldDir)\RimWorldWin64_Data\Managed\UnityEngine.IMGUIModule.dll</HintPath>
   </Reference>
   <Reference Include="UnityEngine.TextRenderingModule">
-    <HintPath>C:\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
+    <HintPath>$(RimWorldDir)\RimWorldWin64_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
   </Reference>
   <Reference Include="UnityEngine.InputLegacyModule">
-    <HintPath>C:\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+    <HintPath>$(RimWorldDir)\RimWorldWin64_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
   </Reference>
   <Reference Include="UnityEngine.AudioModule">
-    <HintPath>C:\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin64_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+    <HintPath>$(RimWorldDir)\RimWorldWin64_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
   </Reference>
 </ItemGroup>
 
@@ -59,19 +64,19 @@
     <!-- Copy the mod DLL -->
     <Copy
       SourceFiles="$(TargetPath)"
-      DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\"
+      DestinationFolder="$(RimWorldDir)\Mods\"
     />
 
     <!-- Copy Tolk.dll -->
     <Copy
       SourceFiles="$(ProjectDir)Tolk.dll"
-      DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\"
+      DestinationFolder="$(RimWorldDir)\Mods\"
     />
 
     <!-- Copy nvdaControllerClient64.dll -->
     <Copy
       SourceFiles="$(ProjectDir)nvdaControllerClient64.dll"
-      DestinationFolder="C:\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\"
+      DestinationFolder="$(RimWorldDir)\Mods\"
     />
   </Target>
 


### PR DESCRIPTION
## Summary
- Replace hardcoded RimWorld install path with configurable `$(RimWorldDir)` MSBuild property
- Developers with non-default installation locations can create a local `GamePaths.props` file to override the path
- Default Steam path still works out of the box - no changes needed for existing developers

## Changes
- Add optional import of `GamePaths.props` in csproj
- Add `GamePaths.props.template` as reference for custom configurations
- Gitignore `GamePaths.props` for local overrides
- Update contributing.md with setup instructions
- Remove references to default install path from CLAUDE.md

## Test plan
- [x] Build succeeds with default path (no GamePaths.props)
- [x] Build succeeds with custom GamePaths.props pointing to non-default location
- [x] DLLs are copied to correct Mods folder after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)