### PR TITLE
feat: Add stone and chunk subcategories to mining scanner

### DIFF
--- a/ScannerHelper.cs
+++ b/ScannerHelper.cs
@@ -672,34 +672,37 @@ namespace RimWorldAccess
         }
 
         /// <summary>
+        /// Unwraps a MinifiedThing to get the actual inner item, or returns the thing as-is.
+        /// Handles MinifiedThing and MinifiedTree (which extends MinifiedThing).
+        /// </summary>
+        private static Thing GetActualThing(Thing thing)
+        {
+            if (thing is MinifiedThing minified && minified.InnerThing != null)
+                return minified.InnerThing;
+            return thing;
+        }
+
+        /// <summary>
         /// Checks if two things are identical (same def, quality, stuff, etc.)
         /// HP differences are ignored to prevent duplicate entries for damaged items.
         /// </summary>
         private static bool AreThingsIdentical(Thing a, Thing b)
         {
-            // For MinifiedThings (uninstalled furniture), compare the inner thing
-            if (a is MinifiedThing minA && b is MinifiedThing minB)
-            {
-                if (minA.InnerThing == null || minB.InnerThing == null)
-                    return false;
-                return AreThingsIdentical(minA.InnerThing, minB.InnerThing);
-            }
-
-            // If only one is minified, they're not identical
-            if (a is MinifiedThing || b is MinifiedThing)
-                return false;
+            // Unwrap minified things to compare actual items
+            var actualA = GetActualThing(a);
+            var actualB = GetActualThing(b);
 
             // Must be the same def
-            if (a.def != b.def)
+            if (actualA.def != actualB.def)
                 return false;
 
             // Must have same stuff (material)
-            if (a.Stuff != b.Stuff)
+            if (actualA.Stuff != actualB.Stuff)
                 return false;
 
             // Check quality if applicable
-            var qualityA = a.TryGetComp<CompQuality>();
-            var qualityB = b.TryGetComp<CompQuality>();
+            var qualityA = actualA.TryGetComp<CompQuality>();
+            var qualityB = actualB.TryGetComp<CompQuality>();
 
             if (qualityA != null && qualityB != null)
             {

--- a/ScannerState.cs
+++ b/ScannerState.cs
@@ -616,12 +616,30 @@ namespace RimWorldAccess
             if (currentBulkIndex < 0 || currentBulkIndex >= item.BulkCount)
                 return;
 
+            // For terrain bulk groups, we don't have individual things
+            if (item.IsTerrain)
+            {
+                var terrainPosition = currentBulkIndex + 1;
+                TolkHelper.Speak($"{item.Label} - {terrainPosition} of {item.BulkCount}", SpeechPriority.Normal);
+                return;
+            }
+
+            // For thing bulk groups, get label from the actual thing at this index
+            if (item.BulkThings == null || currentBulkIndex >= item.BulkThings.Count)
+                return;
+
             var targetThing = item.BulkThings[currentBulkIndex];
+            if (targetThing == null)
+                return;
+
             var cursorPos = MapNavigationState.CurrentCursorPosition;
             var distance = (targetThing.Position - cursorPos).LengthHorizontal;
             var position = currentBulkIndex + 1;
 
-            TolkHelper.Speak($"{item.Label} - {distance:F1} tiles, {position} of {item.BulkCount}", SpeechPriority.Normal);
+            // Build label from this specific thing, not the group label
+            string thingLabel = targetThing.LabelShort ?? targetThing.def?.label ?? item.Label;
+
+            TolkHelper.Speak($"{thingLabel} - {distance:F1} tiles, {position} of {item.BulkCount}", SpeechPriority.Normal);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Reorganizes the Mineable category into three subcategories:
  - **Mineable-Rare**: ore deposits (steel, gold, plasteel, uranium, etc.)
  - **Mineable-Stone**: plain stone nodes (granite, marble, slate, etc.)
  - **Mineable-Chunks**: stone chunks lying on ground
- Fixes bug where MinifiedThings (uninstalled furniture) were incorrectly grouped together

Closes #20

## Changes
- `ScannerHelper.cs`: Added stone/chunk subcategories, fixed MinifiedThing grouping
- Stone chunks captured from `allThings` loop via `IsStoneChunk()` helper
- Plain stone nodes captured in cell loop (isNaturalRock but not isResourceRock)

## Test plan
- [ ] Navigate to Mineable category, verify three subcategories exist
- [ ] Check Mineable-Rare shows ore deposits only
- [ ] Check Mineable-Stone shows plain stone (granite, marble, etc.)
- [ ] Check Mineable-Chunks shows stone chunks on ground
- [ ] Verify uninstalled furniture items are correctly separated (telescope vs sculpture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)