### PR TITLE
feat: Add keyboard accessibility for ideology selection screen

### DIFF
--- a/IdeologyNavigationState.cs
+++ b/IdeologyNavigationState.cs
@@ -1,0 +1,206 @@
+using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using Verse;
+
+namespace RimWorldAccess
+{
+    /// <summary>
+    /// Manages keyboard navigation state for the ideology selection page (Page_ChooseIdeoPreset).
+    /// Similar to ScenarioNavigationState but handles the more complex ideology preset system.
+    /// </summary>
+    public static class IdeologyNavigationState
+    {
+        private static bool initialized = false;
+
+        // Main selection type
+        private enum SelectionType
+        {
+            Classic,
+            CustomFluid,
+            CustomFixed,
+            Load,
+            Preset
+        }
+
+        private static SelectionType currentSelectionType = SelectionType.Classic;
+
+        // For preset browsing
+        private static List<IdeoPresetDef> flatPresetList = new List<IdeoPresetDef>();
+        private static int selectedPresetIndex = 0;
+
+        public static void Initialize()
+        {
+            if (!initialized || flatPresetList.Count == 0)
+            {
+                // Build flat list of all ideology presets (excluding special categories)
+                flatPresetList.Clear();
+
+                var categories = DefDatabase<IdeoPresetCategoryDef>.AllDefsListForReading
+                    .Where(c => c != IdeoPresetCategoryDefOf.Classic &&
+                                c != IdeoPresetCategoryDefOf.Custom &&
+                                c != IdeoPresetCategoryDefOf.Fluid);
+
+                foreach (var category in categories)
+                {
+                    var presetsInCategory = DefDatabase<IdeoPresetDef>.AllDefs
+                        .Where(i => i.categoryDef == category)
+                        .ToList();
+
+                    flatPresetList.AddRange(presetsInCategory);
+                }
+
+                currentSelectionType = SelectionType.Classic;
+                selectedPresetIndex = 0;
+                initialized = true;
+            }
+        }
+
+        public static void Reset()
+        {
+            initialized = false;
+            currentSelectionType = SelectionType.Classic;
+            selectedPresetIndex = 0;
+            flatPresetList.Clear();
+        }
+
+        public static void NavigateUp()
+        {
+            if (currentSelectionType == SelectionType.Preset)
+            {
+                // Navigate through presets
+                if (flatPresetList.Count == 0) return;
+
+                selectedPresetIndex--;
+                if (selectedPresetIndex < 0)
+                    selectedPresetIndex = flatPresetList.Count - 1;
+
+                AnnounceCurrentPreset();
+            }
+            else
+            {
+                // Navigate through main options
+                int currentIndex = (int)currentSelectionType;
+                currentIndex--;
+                if (currentIndex < 0)
+                    currentIndex = 4; // Preset is last
+                currentSelectionType = (SelectionType)currentIndex;
+
+                AnnounceCurrentSelection();
+            }
+        }
+
+        public static void NavigateDown()
+        {
+            if (currentSelectionType == SelectionType.Preset)
+            {
+                // Navigate through presets
+                if (flatPresetList.Count == 0) return;
+
+                selectedPresetIndex++;
+                if (selectedPresetIndex >= flatPresetList.Count)
+                    selectedPresetIndex = 0;
+
+                AnnounceCurrentPreset();
+            }
+            else
+            {
+                // Navigate through main options
+                int currentIndex = (int)currentSelectionType;
+                currentIndex++;
+                if (currentIndex > 4) // Preset is 4
+                    currentIndex = 0;
+                currentSelectionType = (SelectionType)currentIndex;
+
+                AnnounceCurrentSelection();
+            }
+        }
+
+        public static void TogglePresetBrowsing()
+        {
+            if (currentSelectionType == SelectionType.Preset)
+            {
+                // Exit preset browsing - go back to Classic
+                currentSelectionType = SelectionType.Classic;
+                AnnounceCurrentSelection();
+            }
+            else
+            {
+                // Enter preset browsing
+                if (flatPresetList.Count > 0)
+                {
+                    currentSelectionType = SelectionType.Preset;
+                    selectedPresetIndex = 0;
+                    TolkHelper.Speak($"Browsing ideology presets. {flatPresetList.Count} available. Press Tab to return to main options.");
+                    AnnounceCurrentPreset();
+                }
+                else
+                {
+                    TolkHelper.Speak("No ideology presets available");
+                }
+            }
+        }
+
+        private static void AnnounceCurrentSelection()
+        {
+            string announcement = "";
+
+            switch (currentSelectionType)
+            {
+                case SelectionType.Classic:
+                    announcement = $"Play Classic - {IdeoPresetCategoryDefOf.Classic.description}";
+                    break;
+                case SelectionType.CustomFluid:
+                    announcement = $"Create Custom Fluid Ideology - {IdeoPresetCategoryDefOf.Fluid.description}";
+                    break;
+                case SelectionType.CustomFixed:
+                    announcement = $"Create Custom Fixed Ideology - {IdeoPresetCategoryDefOf.Custom.description}";
+                    break;
+                case SelectionType.Load:
+                    announcement = "Load Saved Ideology - Load a previously saved ideology from disk";
+                    break;
+                case SelectionType.Preset:
+                    announcement = "Browse Ideology Presets";
+                    break;
+            }
+
+            TolkHelper.Speak(announcement);
+        }
+
+        private static void AnnounceCurrentPreset()
+        {
+            if (flatPresetList.Count == 0 || selectedPresetIndex < 0 || selectedPresetIndex >= flatPresetList.Count)
+                return;
+
+            var preset = flatPresetList[selectedPresetIndex];
+            string categoryName = preset.categoryDef?.LabelCap ?? "Unknown";
+            string announcement = $"{preset.LabelCap} - {categoryName} - {preset.description} ({selectedPresetIndex + 1} of {flatPresetList.Count})";
+
+            TolkHelper.Speak(announcement);
+        }
+
+        /// <summary>
+        /// Gets the current selection type string for updating the page.
+        /// </summary>
+        public static string GetCurrentSelectionTypeString()
+        {
+            return currentSelectionType.ToString();
+        }
+
+        /// <summary>
+        /// Gets the currently selected ideology preset (or null if not browsing presets).
+        /// </summary>
+        public static IdeoPresetDef GetSelectedPreset()
+        {
+            if (currentSelectionType != SelectionType.Preset)
+                return null;
+
+            if (selectedPresetIndex < 0 || selectedPresetIndex >= flatPresetList.Count)
+                return null;
+
+            return flatPresetList[selectedPresetIndex];
+        }
+
+        public static int PresetCount => flatPresetList.Count;
+    }
+}

--- a/IdeologySelectionPatch.cs
+++ b/IdeologySelectionPatch.cs
@@ -1,0 +1,211 @@
+using HarmonyLib;
+using RimWorld;
+using System.Reflection;
+using UnityEngine;
+using Verse;
+
+namespace RimWorldAccess
+{
+    /// <summary>
+    /// Harmony patches for Page_ChooseIdeoPreset to add keyboard accessibility.
+    /// Only applies when Ideology DLC is active.
+    /// </summary>
+    [HarmonyPatch]
+    public static class IdeologySelectionPatch
+    {
+        private static bool patchActive = false;
+        private static bool hasAnnouncedTitle = false;
+
+        /// <summary>
+        /// Only patch if Ideology DLC is active and the class exists.
+        /// </summary>
+        static bool Prepare()
+        {
+            return ModsConfig.IdeologyActive;
+        }
+
+        /// <summary>
+        /// Target the DoWindowContents method.
+        /// </summary>
+        static MethodBase TargetMethod()
+        {
+            var type = AccessTools.TypeByName("RimWorld.Page_ChooseIdeoPreset");
+            if (type == null)
+            {
+                Log.Warning("[RimWorld Access] Page_ChooseIdeoPreset not found - Ideology DLC may not be installed");
+                return null;
+            }
+            return AccessTools.Method(type, "DoWindowContents");
+        }
+
+        /// <summary>
+        /// Prefix: Initialize state and handle keyboard input.
+        /// IMPORTANT: Parameter must be named "inRect" to match the original method signature.
+        /// </summary>
+        static void Prefix(object __instance, Rect inRect)
+        {
+            try
+            {
+                // Initialize navigation state
+                IdeologyNavigationState.Initialize();
+
+                // Announce window title and initial selection once
+                if (!hasAnnouncedTitle)
+                {
+                    string pageTitle = "Choose Your Ideoligion";
+                    string instructions = "Use Up/Down arrows to navigate, Tab to browse presets, Enter to confirm";
+                    TolkHelper.Speak($"{pageTitle}. {instructions}");
+
+                    // Announce the first option after a brief delay
+                    hasAnnouncedTitle = true;
+
+                    // Announce initial selection
+                    System.Threading.Tasks.Task.Delay(500).ContinueWith(_ =>
+                    {
+                        string description = IdeoPresetCategoryDefOf.Classic.description;
+                        TolkHelper.Speak($"Play Classic - {description}");
+                    });
+                }
+
+                // Handle keyboard input
+                if (Event.current.type == EventType.KeyDown)
+                {
+                    KeyCode keyCode = Event.current.keyCode;
+
+                    if (keyCode == KeyCode.Tab)
+                    {
+                        // Toggle between main options and preset browsing
+                        IdeologyNavigationState.TogglePresetBrowsing();
+                        UpdatePageSelection(__instance);
+                        Event.current.Use();
+                        patchActive = true;
+                    }
+                    else if (keyCode == KeyCode.UpArrow)
+                    {
+                        IdeologyNavigationState.NavigateUp();
+                        UpdatePageSelection(__instance);
+                        Event.current.Use();
+                        patchActive = true;
+                    }
+                    else if (keyCode == KeyCode.DownArrow)
+                    {
+                        IdeologyNavigationState.NavigateDown();
+                        UpdatePageSelection(__instance);
+                        Event.current.Use();
+                        patchActive = true;
+                    }
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Log.Error($"[RimWorld Access] Error in IdeologySelectionPatch Prefix: {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Postfix: Draw visual indicator of keyboard mode.
+        /// </summary>
+        static void Postfix(object __instance, Rect inRect)
+        {
+            try
+            {
+                if (!patchActive) return;
+
+                // Draw a simple indicator at the top
+                Rect indicatorRect = new Rect(inRect.x + 10f, inRect.y + 10f, 300f, 30f);
+                string modeText = "[Keyboard Navigation Active]";
+
+                // Draw semi-transparent background
+                Widgets.DrawBoxSolid(indicatorRect, new Color(0.2f, 0.2f, 0.2f, 0.8f));
+
+                // Draw text
+                Text.Font = GameFont.Small;
+                Text.Anchor = TextAnchor.MiddleCenter;
+                Widgets.Label(indicatorRect, modeText);
+                Text.Anchor = TextAnchor.UpperLeft;
+            }
+            catch (System.Exception ex)
+            {
+                Log.Error($"[RimWorld Access] Error in IdeologySelectionPatch Postfix: {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Updates the page's internal selection state using reflection.
+        /// </summary>
+        private static void UpdatePageSelection(object instance)
+        {
+            try
+            {
+                var instanceType = instance.GetType();
+
+                // Get the private fields
+                FieldInfo presetSelectionField = AccessTools.Field(instanceType, "presetSelection");
+                FieldInfo selectedIdeoField = AccessTools.Field(instanceType, "selectedIdeo");
+
+                if (presetSelectionField == null || selectedIdeoField == null)
+                {
+                    Log.Warning("[RimWorld Access] Could not find required fields in Page_ChooseIdeoPreset");
+                    return;
+                }
+
+                // Get the selection type
+                string selectionType = IdeologyNavigationState.GetCurrentSelectionTypeString();
+
+                // Get the enum type and parse the value
+                System.Type presetSelectionEnumType = presetSelectionField.FieldType;
+                object presetSelectionValue = System.Enum.Parse(presetSelectionEnumType, selectionType);
+
+                // Update the page's presetSelection field
+                presetSelectionField.SetValue(instance, presetSelectionValue);
+
+                // Update the selectedIdeo field
+                if (selectionType == "Preset")
+                {
+                    IdeoPresetDef selectedPreset = IdeologyNavigationState.GetSelectedPreset();
+                    selectedIdeoField.SetValue(instance, selectedPreset);
+                }
+                else
+                {
+                    selectedIdeoField.SetValue(instance, null);
+                }
+            }
+            catch (System.Exception ex)
+            {
+                Log.Error($"[RimWorld Access] Error updating page selection: {ex}");
+            }
+        }
+
+        public static void ResetAnnouncement()
+        {
+            hasAnnouncedTitle = false;
+            patchActive = false;
+        }
+    }
+
+    /// <summary>
+    /// Patch to reset state when the ideology selection page opens.
+    /// </summary>
+    [HarmonyPatch]
+    public static class IdeologySelectionPatch_PostOpen
+    {
+        static bool Prepare()
+        {
+            return ModsConfig.IdeologyActive;
+        }
+
+        static MethodBase TargetMethod()
+        {
+            var type = AccessTools.TypeByName("RimWorld.Page_ChooseIdeoPreset");
+            if (type == null) return null;
+            return AccessTools.Method(type, "PostOpen");
+        }
+
+        [HarmonyPostfix]
+        static void Postfix()
+        {
+            IdeologySelectionPatch.ResetAnnouncement();
+            IdeologyNavigationState.Reset();
+        }
+    }
+}


### PR DESCRIPTION
  - Add IdeologyNavigationState.cs for navigation state management
  - Add IdeologySelectionPatch.cs with DLC check and proper parameter naming
  - Supports Up/Down navigation through main options and ideology presets
  - Tab key toggles between main options and preset browsing
  - Only applies patches when Ideology DLC is active"