### PR TITLE
Fix repeated dialog announcement bug for auto-opening letters

### DIFF
--- a/DialogInterceptionPatch.cs
+++ b/DialogInterceptionPatch.cs
@@ -169,4 +169,27 @@ namespace RimWorldAccess
             GUI.color = prevColor;
         }
     }
+
+    /// <summary>
+    /// Patches WindowStack.WindowsForcePause to account for windowless dialogs.
+    /// This fixes a bug where the game would repeatedly try to open automatic letters
+    /// because it didn't know a forcePause dialog was active (since we intercept and
+    /// don't add them to the window stack).
+    /// </summary>
+    [HarmonyPatch(typeof(WindowStack))]
+    [HarmonyPatch("WindowsForcePause", MethodType.Getter)]
+    public static class WindowsForcePausePatch
+    {
+        [HarmonyPostfix]
+        public static void Postfix(ref bool __result)
+        {
+            // If our windowless dialog system has an active forcePause dialog,
+            // report that the windows force pause even though the dialog isn't
+            // in the actual window stack
+            if (WindowlessDialogState.ShouldForcePause)
+            {
+                __result = true;
+            }
+        }
+    }
 }

--- a/WindowlessDialogState.cs
+++ b/WindowlessDialogState.cs
@@ -21,6 +21,12 @@ namespace RimWorldAccess
         public static bool IsEditingTextField => editingElement != null;
 
         /// <summary>
+        /// Tracks whether the current intercepted dialog has forcePause set.
+        /// Used by WindowsForcePausePatch to maintain game pause behavior.
+        /// </summary>
+        public static bool ShouldForcePause { get; private set; }
+
+        /// <summary>
         /// Opens a windowless version of the given dialog.
         /// </summary>
         public static void Open(Window dialog)
@@ -40,6 +46,11 @@ namespace RimWorldAccess
             CloseActiveMenus();
 
             currentDialog = dialog;
+
+            // Track if this dialog should force pause - used by WindowsForcePausePatch
+            // to prevent game systems from thinking no modal dialog is open
+            ShouldForcePause = dialog.forcePause;
+
             elements = DialogElementExtractor.ExtractElements(dialog);
             selectedIndex = 0;
             editingElement = null;
@@ -93,6 +104,7 @@ namespace RimWorldAccess
             elements.Clear();
             selectedIndex = 0;
             editingElement = null;
+            ShouldForcePause = false;
         }
 
         /// <summary>


### PR DESCRIPTION
When a ChoiceLetter with a timeout was about to expire (e.g., wanderer wants to join colony), the game would call OpenAutomaticLetters() every tick. This method checks WindowStack.WindowsForcePause to see if a dialog is already open.

Since DialogInterceptionPatch intercepts Dialog_NodeTree dialogs and doesn't add them to the actual window stack, WindowsForcePause returned false, causing the game to repeatedly try to open the same dialog. This resulted in the screen reader announcing the dialog hundreds of times per second, each announcement cutting off the previous one.

Fix:
- Add ShouldForcePause property to WindowlessDialogState that tracks whether the intercepted dialog has forcePause=true
- Add WindowsForcePausePatch that patches WindowStack.WindowsForcePause getter to return true when our windowless dialog system has an active forcePause dialog

This ensures game systems correctly detect that a modal dialog is active even when using our windowless dialog system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)