### PR TITLE
feat: FloatMenu interception for gizmos + visibility fix

### DIFF
--- a/DialogInterceptionPatch.cs
+++ b/DialogInterceptionPatch.cs
@@ -19,6 +19,28 @@ namespace RimWorldAccess
             if (window == null)
                 return true;
 
+            // Special handling for FloatMenu when executing a gizmo
+            // (e.g., long-range scanner mineral selection)
+            if (window is FloatMenu floatMenu && GizmoNavigationState.IsExecutingGizmo)
+            {
+
+                // Extract options from the FloatMenu and open windowless version
+                var optionsField = typeof(FloatMenu).GetField("options",
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                if (optionsField != null)
+                {
+                    var options = optionsField.GetValue(floatMenu) as System.Collections.Generic.List<FloatMenuOption>;
+                    if (options != null && options.Count > 0)
+                    {
+                        WindowlessFloatMenuState.Open(options, floatMenu.givesColonistOrders);
+                        return false; // Prevent FloatMenu from being added
+                    }
+                }
+
+                // Fallback: let it through if we couldn't extract options
+                return true;
+            }
+
             // Check if this dialog should be intercepted
             if (!ShouldInterceptDialog(window))
                 return true; // Allow normal behavior


### PR DESCRIPTION
## Summary

- Fixes gizmo visibility check timing in `OpenAtCursor` - Reinstall and other selection-dependent gizmos now appear correctly when navigating with arrow keys
- Adds FloatMenu interception for gizmo actions - menus like the long-range mineral scanner's mineral selection are now keyboard-navigable

## Changes

### GizmoNavigationState.cs
- Added `IsExecutingGizmo` flag to track when a gizmo is being executed
- Wrapped `ProcessInput` calls in try/finally to manage the flag
- Select gizmo owner before non-Designator gizmo execution (fixes scanner action)
- Fixed visibility check timing - now checks `Visible` while thing is still selected

### DialogInterceptionPatch.cs
- Intercept `FloatMenu` windows when `IsExecutingGizmo` is true
- Extract options and open `WindowlessFloatMenuState` instead

### WindowlessFloatMenuState.cs
- Save selection context when menu opens
- Restore selection before executing action (some actions check `Find.Selector.SelectedObjects`)
- Added "{option} selected" announcement after execution

## Test plan

- [x] Arrow key to installed furniture, press G → Reinstall gizmo appears
- [x] Long-range mineral scanner → select mineral from gizmo menu → scanner changes target
- [ ] Verify other gizmo-triggered FloatMenus work
- [ ] Verify normal FloatMenus (right-click orders, etc.) still work normally

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)