### PR TITLE
fix: Clear typeahead search on treeview expand/collapse

### DIFF
--- a/src/Building/ArchitectTreeState.cs
+++ b/src/Building/ArchitectTreeState.cs
@@ -286,6 +286,9 @@ namespace RimWorldAccess
 
             if (item.type == MenuItemType.Category)
             {
+                // Clear search when toggling expansion to avoid stale search state
+                typeahead.ClearSearch();
+
                 // Toggle expansion
                 DesignationCategoryDef category = item.data as DesignationCategoryDef;
                 if (category == null) return;

--- a/src/Inspection/ThingFilterNavigationState.cs
+++ b/src/Inspection/ThingFilterNavigationState.cs
@@ -405,6 +405,9 @@ namespace RimWorldAccess
             if (flattenedNodes.Count == 0 || selectedIndex < 0 || selectedIndex >= flattenedNodes.Count)
                 return;
 
+            // Clear search when expanding to avoid stale search state
+            typeahead.ClearSearch();
+
             var node = flattenedNodes[selectedIndex];
 
             // Case 1: Collapsed category - expand it, focus stays
@@ -457,6 +460,9 @@ namespace RimWorldAccess
         {
             if (flattenedNodes.Count == 0 || selectedIndex < 0 || selectedIndex >= flattenedNodes.Count)
                 return;
+
+            // Clear search when collapsing to avoid stale search state
+            typeahead.ClearSearch();
 
             var node = flattenedNodes[selectedIndex];
 


### PR DESCRIPTION
## Summary
- Clear typeahead search when expanding/collapsing nodes in ArchitectTreeState (Enter key)
- Clear typeahead search when expanding/collapsing nodes in ThingFilterNavigationState (Right/Left arrow keys)

This makes these treeviews consistent with StorageSettingsMenuState which already clears typeahead on expand/collapse.

## Affected menus
- Architect menu (building/construction)
- Food policy filter
- Outfit policy filter

## Test plan
- [x] Open architect menu, type to search, press Enter to expand/collapse a category - search should clear
- [x] Open food/outfit policy filter, type to search, press Right/Left arrow to expand/collapse - search should clear