### PR TITLE
Fix: Add descriptions to order designators in architect menu

### DIFF
--- a/src/Building/ArchitectHelper.cs
+++ b/src/Building/ArchitectHelper.cs
@@ -421,7 +421,7 @@ namespace RimWorldAccess
         /// <summary>
         /// Gets the description text for a designator (for orders/commands).
         /// </summary>
-        private static string GetDesignatorDescriptionText(Designator designator)
+        public static string GetDesignatorDescriptionText(Designator designator)
         {
             if (designator == null)
                 return "";

--- a/src/Building/ArchitectTreeState.cs
+++ b/src/Building/ArchitectTreeState.cs
@@ -126,6 +126,7 @@ namespace RimWorldAccess
         /// <summary>
         /// Gets a label for a designator including cost and description.
         /// Format: "Name: cost (description)" for build designators.
+        /// Format: "Name (description)" for order designators.
         /// </summary>
         private static string GetDesignatorLabel(Designator designator)
         {
@@ -153,6 +154,15 @@ namespace RimWorldAccess
                     {
                         label += $" ({description})";
                     }
+                }
+            }
+            else
+            {
+                // For non-build designators (orders), add description if available
+                string description = ArchitectHelper.GetDesignatorDescriptionText(designator);
+                if (!string.IsNullOrEmpty(description))
+                {
+                    label += $" ({description})";
                 }
             }
 


### PR DESCRIPTION
Fix: Add descriptions to order designators in architect menu