### PR TITLE
fix: Use RimWorld's localized skill descriptors instead of hardcoded English strings

### DIFF
--- a/src/Work/WorkMenuState.cs
+++ b/src/Work/WorkMenuState.cs
@@ -52,32 +52,6 @@ namespace RimWorldAccess
         // Track if changes were made to current pawn
         private static bool hasUnsavedChanges = false;
 
-        // Skill level descriptors (game's 21 levels)
-        private static readonly string[] SkillDescriptors = new string[]
-        {
-            "Barely heard of it",
-            "Utter beginner",
-            "Beginner",
-            "Basic familiarity",
-            "Some familiarity",
-            "Significant familiarity",
-            "Capable amateur",
-            "Weak professional",
-            "Employable professional",
-            "Solid professional",
-            "Skilled professional",
-            "Very skilled professional",
-            "Expert",
-            "Strong expert",
-            "Master",
-            "Strong master",
-            "Region-known master",
-            "Region-leading master",
-            "Planet-known master",
-            "Planet-leading master",
-            "Legendary master"
-        };
-
         public static bool IsActive => isActive;
         public static Pawn CurrentPawn => currentPawn;
         public static int CurrentPawnIndex => currentPawnIndex;
@@ -1047,7 +1021,7 @@ namespace RimWorldAccess
             // Get skill level (average of relevant skills)
             float avgSkill = currentPawn.skills.AverageOfRelevantSkillsFor(workType);
             int skillLevel = Math.Min(20, Math.Max(0, (int)Math.Round(avgSkill)));
-            string descriptor = SkillDescriptors[skillLevel];
+            string descriptor = $"Skill{skillLevel}".Translate();
 
             sb.Append($". Skill level: {skillLevel}, {descriptor}");
 


### PR DESCRIPTION
Use RimWorld's localized skill descriptors instead of hardcoded English strings