### PR TITLE
fix: Prevent crash when trade fails affordability check

### DIFF
--- a/src/Trade/TradeNavigationPatch.cs
+++ b/src/Trade/TradeNavigationPatch.cs
@@ -1,9 +1,58 @@
 using HarmonyLib;
 using RimWorld;
 using Verse;
+using Verse.Sound;
 
 namespace RimWorldAccess
 {
+    /// <summary>
+    /// Patches TradeDeal.TryExecute to handle the case where Dialog_Trade doesn't exist.
+    /// When we close the visual Dialog_Trade for windowless trading, RimWorld's TryExecute
+    /// still expects the window to exist for calling FlashSilver() on affordability failures.
+    /// This patch handles that case gracefully.
+    /// </summary>
+    [HarmonyPatch(typeof(TradeDeal), "TryExecute")]
+    public static class TradeDealTryExecutePatch
+    {
+        /// <summary>
+        /// Prefix that handles the affordability check when Dialog_Trade doesn't exist.
+        /// </summary>
+        [HarmonyPrefix]
+        public static bool Prefix(TradeDeal __instance, ref bool actuallyTraded, ref bool __result)
+        {
+            // Only intervene if we're in windowless trade mode (Dialog_Trade is closed)
+            if (!TradeNavigationState.IsActive)
+                return true; // Let original method run
+
+            // Check if Dialog_Trade exists - if it does, let original method handle everything
+            Dialog_Trade tradeWindow = Find.WindowStack.WindowOfType<Dialog_Trade>();
+            if (tradeWindow != null)
+                return true; // Let original method run
+
+            // Dialog_Trade doesn't exist - we need to handle the affordability check ourselves
+            // to prevent null reference when TryExecute tries to call FlashSilver()
+
+            // Check gift mode first (handled differently)
+            if (TradeSession.giftMode)
+                return true; // Let original method run - gift mode doesn't use FlashSilver
+
+            // Check affordability
+            Tradeable currencyTradeable = __instance.CurrencyTradeable;
+            if (currencyTradeable == null || currencyTradeable.CountPostDealFor(Transactor.Colony) < 0)
+            {
+                // Colony can't afford - announce via screen reader instead of flashing silver
+                TolkHelper.Speak("Cannot complete trade: Colony cannot afford this trade", SpeechPriority.High);
+                SoundDefOf.ClickReject.PlayOneShotOnCamera();
+                actuallyTraded = false;
+                __result = false;
+                return false; // Skip original method
+            }
+
+            // Affordability check passed - let original method continue
+            return true;
+        }
+    }
+
     /// <summary>
     /// Patches Dialog_Trade to intercept and replace it with the windowless trade interface.
     /// </summary>

--- a/src/Trade/TradeNavigationState.cs
+++ b/src/Trade/TradeNavigationState.cs
@@ -630,8 +630,13 @@ namespace RimWorldAccess
 
             if (!result.Accepted)
             {
-                TolkHelper.Speak($"Cannot complete trade: {result.Reason}", SpeechPriority.High);
-                SoundDefOf.ClickReject.PlayOneShotOnCamera();
+                // Only announce if there's an actual reason - the TradeDealTryExecutePatch
+                // may have already announced the failure for affordability issues
+                if (!string.IsNullOrEmpty(result.Reason))
+                {
+                    TolkHelper.Speak($"Cannot complete trade: {result.Reason}", SpeechPriority.High);
+                    SoundDefOf.ClickReject.PlayOneShotOnCamera();
+                }
                 return;
             }
 


### PR DESCRIPTION
When using the windowless trade interface, attempting a trade the colony can't afford (e.g., silver not in beacon range) would crash because RimWorld's `TradeDeal.TryExecute` tries to call `FlashSilver()` on the closed `Dialog_Trade` window.

This adds a Harmony prefix patch that handles the affordability check gracefully when `Dialog_Trade` doesn't exist.