### PR TITLE
Mouse exploration

### DIFF
--- a/src/Input/MapArrowKeyHandler.cs
+++ b/src/Input/MapArrowKeyHandler.cs
@@ -22,6 +22,8 @@ namespace RimWorldAccess
         /// <returns>True if the key was handled, false otherwise</returns>
         public static bool HandleArrowKey(KeyCode key, bool ctrlHeld, bool shiftHeld)
         {
+            MapNavigationPatch.NotifyArrowKeyNavigation();
+
             // Handle Shift+Up/Down for jump mode cycling
             // NOTE: Jump mode cycling now works EVERYWHERE including zone creation mode
             // (previously blocked by incorrect blockJumpModeCycling check)

--- a/src/Input/UnifiedKeyboardPatch.cs
+++ b/src/Input/UnifiedKeyboardPatch.cs
@@ -4320,6 +4320,27 @@ namespace RimWorldAccess
 
             // ===== PRIORITY 10.5: Handle local map arrow key navigation =====
             // Uses Event.current for OS key repeat support (unlike CameraDriver.Update() which uses Input.GetKeyDown)
+            if (key == KeyCode.M && Event.current.shift && !Event.current.control && !Event.current.alt)
+            {
+                if (WorldRendererUtility.WorldRendered)
+                    return;
+
+                if (Current.ProgramState != ProgramState.Playing || Find.CurrentMap == null)
+                    return;
+
+                if (Find.WindowStack?.WindowsPreventCameraMotion == true)
+                    return;
+
+                if (!MapNavigationState.IsInitialized || MapNavigationState.SuppressMapNavigation)
+                    return;
+
+                if (MapNavigationPatch.MoveCursorToLastMouseCell())
+                {
+                    Event.current.Use();
+                }
+                return;
+            }
+
             if (key == KeyCode.UpArrow || key == KeyCode.DownArrow ||
                 key == KeyCode.LeftArrow || key == KeyCode.RightArrow)
             {

--- a/src/Map/MapNavigationPatch.cs
+++ b/src/Map/MapNavigationPatch.cs
@@ -277,6 +277,31 @@ namespace RimWorldAccess
         }
 
         /// <summary>
+        /// Moves the keyboard cursor to the last valid cell discovered by mouse exploration.
+        /// Returns true if the cursor was moved.
+        /// </summary>
+        public static bool MoveCursorToLastMouseCell()
+        {
+            if (Find.CurrentMap == null || !lastMouseCell.IsValid || lastMouseCellMapId != Find.CurrentMap.uniqueID)
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return false;
+            }
+
+            if (!lastMouseCell.InBounds(Find.CurrentMap))
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return false;
+            }
+
+            MapNavigationState.CurrentCursorPosition = lastMouseCell;
+            MapNavigationState.CurrentCameraMode = CameraFollowMode.Cursor;
+            Find.CameraDriver?.JumpToCurrentMapLoc(lastMouseCell);
+            MapArrowKeyHandler.AnnouncePosition(lastMouseCell, Find.CurrentMap);
+            return true;
+        }
+
+        /// <summary>
         /// Handles switching between maps when Shift+comma or Shift+period is pressed.
         /// Restores cursor to last known position on the target map.
         /// </summary>

--- a/src/Map/MapNavigationPatch.cs
+++ b/src/Map/MapNavigationPatch.cs
@@ -222,11 +222,19 @@ namespace RimWorldAccess
                                     tileInfo = "Selected, " + tileInfo;
                                 }
                             }
-                            else if (ArchitectState.IsInPlacementMode && ArchitectState.IsZoneDesignator())
+                            else if (ArchitectState.IsInPlacementMode)
                             {
-                                if (ArchitectState.IsInPreviewMode && ArchitectState.PreviewCells.Contains(mouseCell))
+                                if (ShapePlacementState.IsActive && ShapePlacementState.PreviewCells.Contains(mouseCell))
                                 {
-                                    tileInfo = "Preview, " + tileInfo;
+                                    if (ShapePlacementState.FirstPoint.HasValue && mouseCell == ShapePlacementState.FirstPoint.Value)
+                                    {
+                                        tileInfo = "First point, " + tileInfo;
+                                    }
+                                    else if (ShapePlacementState.CurrentPhase == PlacementPhase.Previewing &&
+                                             ShapePlacementState.SecondPoint.HasValue && mouseCell == ShapePlacementState.SecondPoint.Value)
+                                    {
+                                        tileInfo = "Second point, " + tileInfo;
+                                    }
                                 }
                                 else if (ArchitectState.SelectedCells.Contains(mouseCell))
                                 {

--- a/src/Map/MapNavigationPatch.cs
+++ b/src/Map/MapNavigationPatch.cs
@@ -18,6 +18,9 @@ namespace RimWorldAccess
     {
         private static bool hasAnnouncedThisFrame = false;
         private static int lastProcessedFrame = -1;
+        private static IntVec3 lastMouseCell = IntVec3.Invalid;
+        private static int lastMouseCellMapId = -1;
+        private static float lastArrowKeyPressTime = 0f;
 
         /// <summary>
         /// Updates the map navigation suppression flag based on active menus.
@@ -104,6 +107,8 @@ namespace RimWorldAccess
             if (Find.CurrentMap == null)
             {
                 MapNavigationState.Reset();
+                lastMouseCell = IntVec3.Invalid;
+                lastMouseCellMapId = -1;
                 return true; // Let original run
             }
 
@@ -176,10 +181,91 @@ namespace RimWorldAccess
             // - Frame deduplication
             // - Map changes check and initialization
             // - Map switching with Shift+comma/period
+            // - Mouse exploration announcements while holding Left Shift
+
+            if (!MapNavigationState.SuppressMapNavigation && Find.CurrentMap != null)
+            {
+                bool shiftHeldForMouse = Input.GetKey(KeyCode.LeftShift);
+
+                if (shiftHeldForMouse)
+                {
+                    IntVec3 mouseCell = UI.MouseCell();
+                    if (mouseCell.InBounds(Find.CurrentMap))
+                    {
+                        bool mouseCellChanged = mouseCell != lastMouseCell || Find.CurrentMap.uniqueID != lastMouseCellMapId;
+                        float timeSinceArrowKey = Time.time - lastArrowKeyPressTime;
+                        bool keyboardIdle = timeSinceArrowKey > 0.5f;
+
+                        if (mouseCellChanged && keyboardIdle)
+                        {
+                            string tileInfo = TileInfoHelper.GetTileSummary(mouseCell, Find.CurrentMap);
+
+                            if (ZoneCreationState.IsInCreationMode)
+                            {
+                                if (ZoneCreationState.IsInPreviewMode && ZoneCreationState.PreviewCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Preview, " + tileInfo;
+                                }
+                                else if (ZoneCreationState.IsCellSelected(mouseCell))
+                                {
+                                    tileInfo = "Selected, " + tileInfo;
+                                }
+                            }
+                            else if (AreaPaintingState.IsActive)
+                            {
+                                if (AreaPaintingState.IsInPreviewMode && AreaPaintingState.PreviewCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Preview, " + tileInfo;
+                                }
+                                else if (AreaPaintingState.StagedCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Selected, " + tileInfo;
+                                }
+                            }
+                            else if (ArchitectState.IsInPlacementMode && ArchitectState.IsZoneDesignator())
+                            {
+                                if (ArchitectState.IsInPreviewMode && ArchitectState.PreviewCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Preview, " + tileInfo;
+                                }
+                                else if (ArchitectState.SelectedCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Selected, " + tileInfo;
+                                }
+                            }
+
+                            if (tileInfo != MapNavigationState.LastAnnouncedInfo)
+                            {
+                                TolkHelper.Speak(tileInfo, SpeechPriority.High);
+                                MapNavigationState.LastAnnouncedInfo = tileInfo;
+                                hasAnnouncedThisFrame = true;
+                            }
+
+                            lastMouseCell = mouseCell;
+                            lastMouseCellMapId = Find.CurrentMap.uniqueID;
+                        }
+                    }
+                    else if (lastMouseCell.IsValid || lastMouseCellMapId != -1)
+                    {
+                        lastMouseCell = IntVec3.Invalid;
+                        lastMouseCellMapId = -1;
+                    }
+                }
+                else if (lastMouseCell.IsValid || lastMouseCellMapId != -1)
+                {
+                    lastMouseCell = IntVec3.Invalid;
+                    lastMouseCellMapId = -1;
+                }
+            }
 
             // Let original CameraDriver.Update() run for non-arrow-key functionality
             // (zoom, following, etc.)
             return true;
+        }
+
+        public static void NotifyArrowKeyNavigation()
+        {
+            lastArrowKeyPressTime = Time.time;
         }
 
         /// <summary>

--- a/src/World/WorldNavigationPatch.cs
+++ b/src/World/WorldNavigationPatch.cs
@@ -336,10 +336,10 @@ namespace RimWorldAccess
             if (!WorldNavigationState.IsActive || !WorldNavigationState.IsInitialized)
                 return;
 
-            // Check if left Ctrl is held down
-            bool ctrlHeldForMouse = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+            // Check if left Shift is held down to avoid screen reader Ctrl interruption
+            bool shiftHeldForMouse = Input.GetKey(KeyCode.LeftShift);
 
-            if (ctrlHeldForMouse)
+            if (shiftHeldForMouse)
             {
                 // Get current mouse tile on world map
                 int mouseTile = -1;
@@ -387,7 +387,7 @@ namespace RimWorldAccess
             }
             else
             {
-                // Ctrl is not held - reset tracking to ensure clean state
+                // Shift is not held - reset tracking to ensure clean state
                 if (lastWorldMouseTile != -1)
                 {
                     lastWorldMouseTile = -1;

--- a/src/World/WorldNavigationPatch.cs
+++ b/src/World/WorldNavigationPatch.cs
@@ -146,6 +146,13 @@ namespace RimWorldAccess
                 return;
             }
 
+            if (key == KeyCode.M && shift && !ctrl && !alt)
+            {
+                MoveSelectionToLastMouseTile();
+                Event.current.Use();
+                return;
+            }
+
             // Note: Comma and Period keys for caravan cycling are handled in UnifiedKeyboardPatch
             // at a higher priority to prevent colonist selection from intercepting them
 
@@ -393,6 +400,40 @@ namespace RimWorldAccess
                     lastWorldMouseTile = -1;
                 }
             }
+        }
+
+        /// <summary>
+        /// Moves world navigation to the last valid tile discovered by mouse exploration.
+        /// </summary>
+        private static void MoveSelectionToLastMouseTile()
+        {
+            if (lastWorldMouseTile < 0)
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return;
+            }
+
+            PlanetTile tile = new PlanetTile(lastWorldMouseTile);
+            if (!tile.Valid)
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return;
+            }
+
+            WorldNavigationState.CurrentSelectedTile = tile;
+
+            if (Find.WorldSelector != null)
+            {
+                Find.WorldSelector.ClearSelection();
+                Find.WorldSelector.SelectedTile = tile;
+            }
+
+            if (Find.WorldCameraDriver != null)
+            {
+                Find.WorldCameraDriver.JumpTo(tile);
+            }
+
+            WorldNavigationState.AnnounceTile();
         }
     }
 }


### PR DESCRIPTION
This PR introduces a mouse-driven exploration mode to enhance spatial awareness on both the colony and world maps.
Key Changes:

* Mouse Exploration Toggle: Holding Left Ctrl now activates a mouse-tracking mode.
* Cursor-to-Tile Navigation: Moving the mouse cursor over the map triggers the same descriptive feedback as keyboard-based (arrow keys) navigation.
* Spatial Feedback: This feature allows users to bridge the gap between abstract coordinate feedback (from screen readers like NVDA) and the physical layout of the map.

Use Case: When used in conjunction with screen reader features (such as NVDA's audio mouse coordinates), this allows for a more intuitive understanding of the relative positions of objects, buildings, and terrain zones by physically "scanning" the game area with mouse.