### PR TITLE
fix: allow creating multiple zones of the same type

### DIFF
--- a/src/Building/ShapePlacementState.cs
+++ b/src/Building/ShapePlacementState.cs
@@ -198,6 +198,16 @@ namespace RimWorldAccess
             // This ensures the zone selection matches what's announced on entry
             entryCursorPosition = MapNavigationState.CurrentCursorPosition;
 
+            // For zone designators, clear any existing zone selection.
+            // The expand/create decision should be based purely on cursor position,
+            // not on what zone happens to be selected from a previous operation.
+            // This ensures the actual behavior matches the announcement made on entry.
+            // Note: The gizmo-based expand flow uses GizmoZoneEditState, which preserves selection.
+            if (ShapeHelper.IsZoneDesignator(designator))
+            {
+                Find.Selector.ClearSelection();
+            }
+
             string shapeName = ShapeHelper.GetShapeName(shape);
             string designatorLabel = ArchitectHelper.GetSanitizedLabel(designator);
 


### PR DESCRIPTION
Previously, users could only create one zone of each type (stockpile,
growing, etc.). Attempting to create a second zone away from the first
would fail with "no valid cells" even though the announcement correctly
said "will create new zone".

Root cause: When entering shape placement mode, if a zone was still
selected from a previous operation, ZoneSelectionHelper.SelectZoneAtCell()
would prioritize that selection over the actual cursor position. This
caused the code to try expanding the old zone instead of creating a new
one, and since the new cells weren't adjacent, all cells were filtered
out by FilterCellsForExpansion().

The fix clears zone selection when entering ShapePlacementState for zone
designators. This ensures the expand/create decision is based purely on
cursor position, matching the announcement behavior. The gizmo-based
expand/shrink flow is unaffected since it uses GizmoZoneEditState which
has its own selection handling.