### PR TITLE
feat: add pen stats to tile info hotkey

### DIFF
--- a/src/Map/DetailInfoPatch.cs
+++ b/src/Map/DetailInfoPatch.cs
@@ -6,7 +6,7 @@ namespace RimWorldAccess
 {
     /// <summary>
     /// Harmony patch to add hotkeys for specific tile information categories.
-    // Keys 1-7: 1=Items/Pawns, 2=Flooring, 3=Plants, 4=Brightness/Temp, 5=Room Stats, 6=Power, 7=Areas
+    // Keys 1-8: 1=Items/Pawns, 2=Flooring, 3=Plants, 4=Brightness/Temp, 5=Room Stats/Pens, 6=Power, 7=Areas, 8=Jump to pen marker
     /// </summary>
     [HarmonyPatch(typeof(CameraDriver))]
     [HarmonyPatch("Update")]
@@ -42,7 +42,7 @@ namespace RimWorldAccess
             if (Input.GetKey(KeyCode.LeftShift) || Input.GetKey(KeyCode.RightShift))
                 return;
 
-            // Check for tile info hotkeys (1-7 keys, both alpha and keypad)
+            // Check for tile info hotkeys (1-8 keys, both alpha and keypad)
             KeyCode? pressedKey = null;
             if (Input.GetKeyDown(KeyCode.Alpha1) || Input.GetKeyDown(KeyCode.Keypad1))
                 pressedKey = KeyCode.Alpha1;
@@ -58,6 +58,8 @@ namespace RimWorldAccess
                 pressedKey = KeyCode.Alpha6;
             else if (Input.GetKeyDown(KeyCode.Alpha7) || Input.GetKeyDown(KeyCode.Keypad7))
                 pressedKey = KeyCode.Alpha7;
+            else if (Input.GetKeyDown(KeyCode.Alpha8) || Input.GetKeyDown(KeyCode.Keypad8))
+                pressedKey = KeyCode.Alpha8;
 
             if (pressedKey.HasValue)
             {
@@ -134,6 +136,8 @@ namespace RimWorldAccess
                     return TileInfoHelper.GetPowerInfo(position, map);
                 case KeyCode.Alpha7:
                     return TileInfoHelper.GetAreasInfo(position, map);
+                case KeyCode.Alpha8:
+                    return PenInfoHelper.JumpToPenMarker(position, map);
                 default:
                     return "Unknown key";
             }

--- a/src/Map/PenInfoHelper.cs
+++ b/src/Map/PenInfoHelper.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using RimWorld;
 using Verse;
@@ -31,19 +32,22 @@ namespace RimWorldAccess
             if (pen == null)
                 return null;
 
+            PenFoodCalculator calculator = pen.MarkerComp?.PenFoodCalculator;
+            List<string> warnings = GetWarnings(pen, calculator);
+            string animalComposition = GetAnimalComposition(calculator);
+
             var sb = new StringBuilder();
+            sb.Append("Pen");
+            sb.Append(": ");
             sb.Append(GetPenLabel(pen.Marker));
             sb.Append($", size: {pen.Cells.Count} cells");
 
-            if (!pen.IsEnclosed)
+            if (warnings.Count > 0)
             {
-                sb.Append(", not enclosed");
-                return sb.ToString();
+                sb.Append(", warnings: ");
+                sb.Append(string.Join("; ", warnings));
             }
 
-            sb.Append(", enclosed");
-
-            PenFoodCalculator calculator = pen.MarkerComp?.PenFoodCalculator;
             if (calculator == null)
                 return sb.ToString();
 
@@ -55,25 +59,22 @@ namespace RimWorldAccess
             sb.Append($", nutrition balance: {balanceSign}{balance:F1} per day");
             sb.Append($", growth: {growth:F1}");
             sb.Append($", consumption: {consumption:F1}");
+            sb.Append($", stockpiled: {calculator.sumStockpiledNutritionAvailableNow:F1}");
 
-            if (calculator.sumStockpiledNutritionAvailableNow > 0f)
-            {
-                sb.Append($", stockpiled: {calculator.sumStockpiledNutritionAvailableNow:F1}");
-            }
-
-            int animalCount = 0;
-            int animalTypes = 0;
-            if (calculator.ActualAnimalInfos != null)
-            {
-                animalTypes = calculator.ActualAnimalInfos.Count;
-                animalCount = calculator.ActualAnimalInfos.Sum(info => info.count);
-            }
+            int animalCount = calculator.ActualAnimalInfos?.Sum(info => info.count) ?? 0;
+            int animalTypes = calculator.ActualAnimalInfos?.Count ?? 0;
 
             if (animalCount > 0)
             {
                 sb.Append($", animals: {animalCount}");
                 if (animalTypes > 1)
                     sb.Append($" ({animalTypes} types)");
+
+                if (!string.IsNullOrEmpty(animalComposition))
+                {
+                    sb.Append(", composition: ");
+                    sb.Append(animalComposition);
+                }
             }
             else
             {
@@ -215,8 +216,74 @@ namespace RimWorldAccess
             if (marker == null)
                 return "Animal pen";
 
-            string label = marker.LabelCap?.StripTags();
+            PropertyInfo renamableLabelProp = marker.GetType().GetProperty("RenamableLabel");
+            string label = renamableLabelProp?.GetValue(marker) as string;
+            if (string.IsNullOrWhiteSpace(label))
+                label = marker.LabelCap;
+
             return string.IsNullOrWhiteSpace(label) ? "Animal pen" : label;
+        }
+
+        private static List<string> GetWarnings(PenData pen, PenFoodCalculator calculator)
+        {
+            var warnings = new List<string>();
+
+            if (pen == null)
+                return warnings;
+
+            if (!pen.IsEnclosed)
+                warnings.Add("AlertAnimalPenNotEnclosed".Translate().RawText);
+
+            if (calculator == null)
+                return warnings;
+
+            float balance = calculator.NutritionPerDayToday - calculator.SumNutritionConsumptionPerDay;
+            if (balance < 0f)
+                warnings.Add($"losing nutrition ({balance:F1} per day)");
+
+            if (calculator.sumStockpiledNutritionAvailableNow <= 0f)
+                warnings.Add("no stockpiled food");
+
+            int animalCount = calculator.ActualAnimalInfos?.Sum(info => info.count) ?? 0;
+            if (animalCount == 0)
+                warnings.Add("no animals assigned");
+
+            return warnings;
+        }
+
+        private static string GetAnimalComposition(PenFoodCalculator calculator)
+        {
+            if (calculator?.ActualAnimalInfos == null || calculator.ActualAnimalInfos.Count == 0)
+                return null;
+
+            var parts = new List<string>();
+            foreach (var info in calculator.ActualAnimalInfos.OrderByDescending(info => info.count))
+            {
+                string animalLabel = info.animalDef?.label?.CapitalizeFirst() ?? "Unknown";
+                parts.Add($"{animalLabel} {info.count}");
+            }
+
+            return string.Join(", ", parts);
+        }
+
+        /// <summary>
+        /// Jumps to the pen marker for the pen at the given position.
+        /// Returns a spoken message describing the result.
+        /// </summary>
+        public static string JumpToPenMarker(IntVec3 position, Map map)
+        {
+            PenData pen = FindContainingPen(position, map);
+            if (pen?.Marker == null || map == null)
+                return "No pen at cursor";
+
+            IntVec3 markerPosition = pen.Marker.Position;
+            if (!markerPosition.InBounds(map))
+                return "Pen marker not found";
+
+            MapNavigationState.CurrentCursorPosition = markerPosition;
+            Find.CameraDriver?.JumpToCurrentMapLoc(markerPosition);
+
+            return $"Jumped to pen marker: {GetPenLabel(pen.Marker)}";
         }
     }
 }

--- a/src/Map/PenInfoHelper.cs
+++ b/src/Map/PenInfoHelper.cs
@@ -35,16 +35,21 @@ namespace RimWorldAccess
             PenFoodCalculator calculator = pen.MarkerComp?.PenFoodCalculator;
             List<string> warnings = GetWarnings(pen, calculator);
             string animalComposition = GetAnimalComposition(calculator);
+            string growthLabel = "PenFoodTab_NaturalNutritionGrowthRate".Translate().RawText;
+            string consumptionLabel = "PenFoodTab_TotalNutritionConsumptionRate".Translate().RawText;
+            string stockpiledLabel = "PenFoodTab_StockpileTotal".Translate().RawText;
+            string countLabel = "PenFoodTab_Count".Translate().RawText;
+            string animalTypeLabel = "PenFoodTab_AnimalType".Translate().RawText;
+            string noneLabel = "NoneLower".Translate().RawText;
+            string balanceLabel = $"{growthLabel} - {consumptionLabel}";
 
             var sb = new StringBuilder();
-            sb.Append("Pen");
-            sb.Append(": ");
             sb.Append(GetPenLabel(pen.Marker));
             sb.Append($", size: {pen.Cells.Count} cells");
 
             if (warnings.Count > 0)
             {
-                sb.Append(", warnings: ");
+                sb.Append(", ");
                 sb.Append(string.Join("; ", warnings));
             }
 
@@ -56,30 +61,14 @@ namespace RimWorldAccess
             float balance = growth - consumption;
             string balanceSign = balance >= 0f ? "+" : "";
 
-            sb.Append($", nutrition balance: {balanceSign}{balance:F1} per day");
-            sb.Append($", growth: {growth:F1}");
-            sb.Append($", consumption: {consumption:F1}");
-            sb.Append($", stockpiled: {calculator.sumStockpiledNutritionAvailableNow:F1}");
+            sb.Append($", {growthLabel}: {growth:F1}");
+            sb.Append($", {consumptionLabel}: {consumption:F1}");
+            sb.Append($", {stockpiledLabel}: {calculator.sumStockpiledNutritionAvailableNow:F1}");
+            sb.Append($", {balanceLabel}: {balanceSign}{balance:F1}");
 
             int animalCount = calculator.ActualAnimalInfos?.Sum(info => info.count) ?? 0;
-            int animalTypes = calculator.ActualAnimalInfos?.Count ?? 0;
-
-            if (animalCount > 0)
-            {
-                sb.Append($", animals: {animalCount}");
-                if (animalTypes > 1)
-                    sb.Append($" ({animalTypes} types)");
-
-                if (!string.IsNullOrEmpty(animalComposition))
-                {
-                    sb.Append(", composition: ");
-                    sb.Append(animalComposition);
-                }
-            }
-            else
-            {
-                sb.Append(", no animals");
-            }
+            sb.Append($", {countLabel}: {animalCount}");
+            sb.Append($", {animalTypeLabel}: {animalComposition ?? noneLabel}");
 
             return sb.ToString();
         }
@@ -239,14 +228,11 @@ namespace RimWorldAccess
 
             float balance = calculator.NutritionPerDayToday - calculator.SumNutritionConsumptionPerDay;
             if (balance < 0f)
-                warnings.Add($"losing nutrition ({balance:F1} per day)");
-
-            if (calculator.sumStockpiledNutritionAvailableNow <= 0f)
-                warnings.Add("no stockpiled food");
+                warnings.Add($"{ "PenFoodTab_NaturalNutritionGrowthRate".Translate().RawText } < { "PenFoodTab_TotalNutritionConsumptionRate".Translate().RawText }");
 
             int animalCount = calculator.ActualAnimalInfos?.Sum(info => info.count) ?? 0;
             if (animalCount == 0)
-                warnings.Add("no animals assigned");
+                warnings.Add($"{ "PenFoodTab_AnimalType".Translate().RawText }: { "NoneLower".Translate().RawText }");
 
             return warnings;
         }
@@ -274,16 +260,16 @@ namespace RimWorldAccess
         {
             PenData pen = FindContainingPen(position, map);
             if (pen?.Marker == null || map == null)
-                return "No pen at cursor";
+                return "None".Translate().RawText;
 
             IntVec3 markerPosition = pen.Marker.Position;
             if (!markerPosition.InBounds(map))
-                return "Pen marker not found";
+                return "None".Translate().RawText;
 
             MapNavigationState.CurrentCursorPosition = markerPosition;
             Find.CameraDriver?.JumpToCurrentMapLoc(markerPosition);
 
-            return $"Jumped to pen marker: {GetPenLabel(pen.Marker)}";
+            return GetPenLabel(pen.Marker);
         }
     }
 }

--- a/src/Map/PenInfoHelper.cs
+++ b/src/Map/PenInfoHelper.cs
@@ -1,0 +1,222 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RimWorld;
+using Verse;
+
+namespace RimWorldAccess
+{
+    /// <summary>
+    /// Helper for detecting and describing animal pens at the cursor position.
+    /// Pens are outdoors enclosures, so they need separate handling from room stats.
+    /// </summary>
+    public static class PenInfoHelper
+    {
+        private const int MaxPenCells = 20000;
+
+        private sealed class PenData
+        {
+            public Building Marker { get; set; }
+            public CompAnimalPenMarker MarkerComp { get; set; }
+            public HashSet<IntVec3> Cells { get; set; }
+            public bool IsEnclosed { get; set; }
+        }
+
+        /// <summary>
+        /// Gets pen statistics for a position, or null if the position is not part of a detected pen.
+        /// </summary>
+        public static string GetPenStatsInfo(IntVec3 position, Map map)
+        {
+            PenData pen = FindContainingPen(position, map);
+            if (pen == null)
+                return null;
+
+            var sb = new StringBuilder();
+            sb.Append(GetPenLabel(pen.Marker));
+            sb.Append($", size: {pen.Cells.Count} cells");
+
+            if (!pen.IsEnclosed)
+            {
+                sb.Append(", not enclosed");
+                return sb.ToString();
+            }
+
+            sb.Append(", enclosed");
+
+            PenFoodCalculator calculator = pen.MarkerComp?.PenFoodCalculator;
+            if (calculator == null)
+                return sb.ToString();
+
+            float growth = calculator.NutritionPerDayToday;
+            float consumption = calculator.SumNutritionConsumptionPerDay;
+            float balance = growth - consumption;
+            string balanceSign = balance >= 0f ? "+" : "";
+
+            sb.Append($", nutrition balance: {balanceSign}{balance:F1} per day");
+            sb.Append($", growth: {growth:F1}");
+            sb.Append($", consumption: {consumption:F1}");
+
+            if (calculator.sumStockpiledNutritionAvailableNow > 0f)
+            {
+                sb.Append($", stockpiled: {calculator.sumStockpiledNutritionAvailableNow:F1}");
+            }
+
+            int animalCount = 0;
+            int animalTypes = 0;
+            if (calculator.ActualAnimalInfos != null)
+            {
+                animalTypes = calculator.ActualAnimalInfos.Count;
+                animalCount = calculator.ActualAnimalInfos.Sum(info => info.count);
+            }
+
+            if (animalCount > 0)
+            {
+                sb.Append($", animals: {animalCount}");
+                if (animalTypes > 1)
+                    sb.Append($" ({animalTypes} types)");
+            }
+            else
+            {
+                sb.Append(", no animals");
+            }
+
+            return sb.ToString();
+        }
+
+        private static PenData FindContainingPen(IntVec3 position, Map map)
+        {
+            if (map == null || !position.InBounds(map))
+                return null;
+
+            List<IntVec3> targetCells = GetCandidateTargetCells(position, map);
+            if (targetCells.Count == 0)
+                return null;
+
+            foreach (Building building in map.listerBuildings.allBuildingsColonist)
+            {
+                CompAnimalPenMarker markerComp = building.TryGetComp<CompAnimalPenMarker>();
+                if (markerComp == null)
+                    continue;
+
+                PenData pen = BuildPenData(building, markerComp, map);
+                if (pen == null)
+                    continue;
+
+                if (position == building.Position)
+                    return pen;
+
+                if (targetCells.Any(cell => pen.Cells.Contains(cell)))
+                    return pen;
+            }
+
+            return null;
+        }
+
+        private static List<IntVec3> GetCandidateTargetCells(IntVec3 position, Map map)
+        {
+            var cells = new List<IntVec3>();
+
+            if (CanOccupyPenCell(position, map))
+                cells.Add(position);
+
+            foreach (IntVec3 offset in GenAdj.CardinalDirections)
+            {
+                IntVec3 adjacent = position + offset;
+                if (adjacent.InBounds(map) && CanOccupyPenCell(adjacent, map) && !cells.Contains(adjacent))
+                    cells.Add(adjacent);
+            }
+
+            return cells;
+        }
+
+        private static PenData BuildPenData(Building marker, CompAnimalPenMarker markerComp, Map map)
+        {
+            if (marker == null || markerComp == null || map == null || !marker.Spawned)
+                return null;
+
+            var visited = new HashSet<IntVec3>();
+            var queue = new Queue<IntVec3>();
+            bool reachedEdge = false;
+
+            if (!marker.Position.InBounds(map))
+                return null;
+
+            queue.Enqueue(marker.Position);
+            visited.Add(marker.Position);
+
+            while (queue.Count > 0)
+            {
+                IntVec3 current = queue.Dequeue();
+
+                if (visited.Count >= MaxPenCells)
+                {
+                    reachedEdge = true;
+                    break;
+                }
+
+                if (current.x == 0 || current.z == 0 || current.x == map.Size.x - 1 || current.z == map.Size.z - 1)
+                {
+                    reachedEdge = true;
+                }
+
+                foreach (IntVec3 offset in GenAdj.CardinalDirections)
+                {
+                    IntVec3 next = current + offset;
+                    if (!next.InBounds(map) || visited.Contains(next))
+                        continue;
+
+                    if (!CanOccupyPenCell(next, map))
+                        continue;
+
+                    visited.Add(next);
+                    queue.Enqueue(next);
+                }
+            }
+
+            return new PenData
+            {
+                Marker = marker,
+                MarkerComp = markerComp,
+                Cells = visited,
+                IsEnclosed = !reachedEdge
+            };
+        }
+
+        private static bool CanOccupyPenCell(IntVec3 cell, Map map)
+        {
+            if (!cell.InBounds(map))
+                return false;
+
+            if (cell.Impassable(map))
+                return false;
+
+            foreach (Thing thing in cell.GetThingList(map))
+            {
+                if (!(thing is Building building))
+                    continue;
+
+                if (building.TryGetComp<CompAnimalPenMarker>() != null)
+                    continue;
+
+                BuildingProperties props = building.def?.building;
+                if (props == null)
+                    continue;
+
+                // Treat pen boundaries like rooms treat walls: fences, walls, and doors block the flood fill.
+                if (props.isFence || props.isWall || building is Building_Door)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static string GetPenLabel(Building marker)
+        {
+            if (marker == null)
+                return "Animal pen";
+
+            string label = marker.LabelCap?.StripTags();
+            return string.IsNullOrWhiteSpace(label) ? "Animal pen" : label;
+        }
+    }
+}

--- a/src/Map/TileInfoHelper.cs
+++ b/src/Map/TileInfoHelper.cs
@@ -736,6 +736,10 @@ namespace RimWorldAccess
             if (map == null || !position.InBounds(map))
                 return "Out of bounds";
 
+            string penInfo = PenInfoHelper.GetPenStatsInfo(position, map);
+            if (!string.IsNullOrEmpty(penInfo))
+                return penInfo;
+
             Room room = position.GetRoom(map);
 
             if (room == null)


### PR DESCRIPTION
## Summary
- add pen-specific output for hotkey 5 when the cursor is on a fence tile or inside an animal pen
- preserve the existing room-stat announcement for proper rooms and outdoors fallback elsewhere
- report pen enclosure, size, nutrition balance, stockpiled nutrition, and animal counts from the pen marker data