### PR TITLE
feat(anomaly): add Entity Codex keyboard navigation with typeahead search

### DIFF
--- a/src/Anomaly/CLAUDE.md
+++ b/src/Anomaly/CLAUDE.md
@@ -1,0 +1,66 @@
+# Anomaly Module
+
+Screen reader accessibility for RimWorld's Anomaly DLC.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `EntityCodexState.cs` | Navigation state for `Dialog_EntityCodex` — flat menu with typeahead search |
+| `EntityCodexPatch.cs` | Harmony patches for `Dialog_EntityCodex` lifecycle (PostOpen, PostClose, OnCancelKeyPressed) |
+
+## EntityCodexState
+
+Handles keyboard navigation inside `Dialog_EntityCodex`, the in-game browsable codex of discovered entities.
+
+### Architecture
+
+Follows the State + Patch pattern from `src/Rituals/DryadCasteState.cs`. The state builds a flat list of all visible `EntityCodexEntryDef` entries ordered by category (`listOrder`) then by `orderInCategory`. TypeaheadSearchHelper enables incremental search across entry names.
+
+### Keyboard map
+
+| Key | Action |
+|-----|--------|
+| Up / Down | Navigate entries |
+| Home / End | Jump to first / last entry |
+| Enter | Re-announce current entry |
+| Letters / Digits | Typeahead search |
+| Backspace | Remove last typeahead character |
+| Escape (search active) | Clear search, return to position announcement |
+| Escape (no search) | Close the dialog |
+
+### Announcement format
+
+**Discovered entry:** `"{LabelCap}, {category LabelCap}. {description}. {linked things}. {position}"`
+
+**Undiscovered entry:** `"UndiscoveredEntity (translated), {category LabelCap}. UndiscoveredEntityDesc (translated). {position}"`
+
+### Translatable strings used
+
+- `"EntityCodex".Translate()` — dialog title in open announcement
+- `"UndiscoveredEntity".Translate()` — label for entries not yet discovered
+- `"UndiscoveredEntityDesc".Translate()` — description placeholder for undiscovered entries
+- `entry.LabelCap` / `entry.category.LabelCap` — def-sourced names (translated via XML)
+- `entry.Description` — def-sourced description (translated via XML)
+
+### Hardcoded English strings
+
+- `"entries."` — entry count suffix in open announcement
+- `"Entity Codex closed."` — close notification
+- `"No matches for '...'"` — typeahead failure message
+
+## Coverage notes
+
+### Already covered by existing systems
+
+| Feature | Handler |
+|---------|---------|
+| Void monolith investigate dialog (`Dialog_NodeTree`) | `WindowlessDialogState` |
+| Void monolith activated dialog (`Dialog_NodeTree`) | `WindowlessDialogState` |
+| Study Notes tab (`ITab_StudyNotesVoidMonolith`) | `TabRegistry` → `BasicInspectString` |
+| Entity tab (`ITab_Entity`) | `TabRegistry` → `BasicInspectString` |
+| Monolith gizmo navigation | `GizmoNavigationState` (generic) |
+
+### Priority
+
+`EntityCodexState` is registered in `UnifiedKeyboardPatch` at **priority 4.64**, between the options menu (4.6) and the research menu (4.7).

--- a/src/Anomaly/EntityCodexPatch.cs
+++ b/src/Anomaly/EntityCodexPatch.cs
@@ -1,0 +1,61 @@
+using System;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace RimWorldAccess
+{
+    public static class EntityCodexPatch
+    {
+        [HarmonyPatch(typeof(Window), "PostOpen")]
+        public static class Window_PostOpen_EntityCodex_Patch
+        {
+            [HarmonyPostfix]
+            public static void Postfix(Window __instance)
+            {
+                if (!(__instance is Dialog_EntityCodex dialog))
+                    return;
+                try
+                {
+                    EntityCodexState.Open(dialog);
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"[EntityCodexPatch] Error in PostOpen: {ex.Message}");
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(Window), "PostClose")]
+        public static class Window_PostClose_EntityCodex_Patch
+        {
+            [HarmonyPostfix]
+            public static void Postfix(Window __instance)
+            {
+                if (!(__instance is Dialog_EntityCodex))
+                    return;
+                try
+                {
+                    if (EntityCodexState.IsActive)
+                        EntityCodexState.Close();
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"[EntityCodexPatch] Error in PostClose: {ex.Message}");
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(Window), "OnCancelKeyPressed")]
+        public static class Window_OnCancelKeyPressed_EntityCodex_Patch
+        {
+            [HarmonyPrefix]
+            public static bool Prefix(Window __instance)
+            {
+                if (__instance is Dialog_EntityCodex && EntityCodexState.IsActive)
+                    return false;
+                return true;
+            }
+        }
+    }
+}

--- a/src/Anomaly/EntityCodexPatch.cs
+++ b/src/Anomaly/EntityCodexPatch.cs
@@ -37,7 +37,10 @@ namespace RimWorldAccess
                 try
                 {
                     if (EntityCodexState.IsActive)
+                    {
                         EntityCodexState.Close();
+                        TolkHelper.Speak($"{"EntityCodex".Translate()} closed.");
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/src/Anomaly/EntityCodexState.cs
+++ b/src/Anomaly/EntityCodexState.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace RimWorldAccess
+{
+    public static class EntityCodexState
+    {
+        private static bool isActive;
+        private static Dialog_EntityCodex currentDialog;
+        private static List<EntityCodexEntryDef> allEntries = new List<EntityCodexEntryDef>();
+        private static int selectedIndex;
+        private static TypeaheadSearchHelper typeaheadHelper = new TypeaheadSearchHelper();
+
+        public static bool IsActive => isActive;
+        public static bool HasActiveSearch => typeaheadHelper.HasActiveSearch;
+
+        public static void Open(Dialog_EntityCodex dialog)
+        {
+            if (dialog == null)
+                return;
+
+            try
+            {
+                currentDialog = dialog;
+                typeaheadHelper.ClearSearch();
+                selectedIndex = 0;
+
+                // Build flat entry list ordered by category listOrder, then orderInCategory, then label.
+                allEntries = DefDatabase<EntityCategoryDef>.AllDefsListForReading
+                    .Where(HasVisibleEntries)
+                    .OrderBy(c => c.listOrder)
+                    .SelectMany(c => DefDatabase<EntityCodexEntryDef>.AllDefsListForReading
+                        .Where(e => e.Visible && e.category == c)
+                        .OrderBy(e => e.orderInCategory)
+                        .ThenBy(e => e.LabelCap.ToString()))
+                    .ToList();
+
+                isActive = true;
+
+                string title = "EntityCodex".Translate().Resolve();
+                TolkHelper.Speak($"{title}. {allEntries.Count} entries.", SpeechPriority.Normal);
+
+                if (allEntries.Count > 0)
+                    AnnounceCurrentSelection();
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"[EntityCodexState] Error opening: {ex.Message}");
+                Close();
+            }
+        }
+
+        public static void Close()
+        {
+            isActive = false;
+            currentDialog = null;
+            allEntries.Clear();
+            selectedIndex = 0;
+            typeaheadHelper.ClearSearch();
+        }
+
+        public static bool HandleInput(Event evt)
+        {
+            if (!isActive || currentDialog == null) return false;
+            if (evt.type != EventType.KeyDown) return false;
+
+            var key = evt.keyCode;
+            bool ctrl = evt.control;
+            bool alt = KeyboardHelper.IsAltHeld;
+
+            // Modal dialog: consume all modifier-key combos.
+            if (ctrl || alt) return true;
+
+            switch (key)
+            {
+                case KeyCode.Home:
+                    typeaheadHelper.ClearSearch();
+                    selectedIndex = MenuHelper.JumpToFirst();
+                    AnnounceCurrentSelection();
+                    return true;
+
+                case KeyCode.End:
+                    typeaheadHelper.ClearSearch();
+                    selectedIndex = MenuHelper.JumpToLast(allEntries.Count);
+                    AnnounceCurrentSelection();
+                    return true;
+
+                case KeyCode.Escape:
+                    if (typeaheadHelper.HasActiveSearch)
+                    {
+                        typeaheadHelper.ClearSearchAndAnnounce();
+                        AnnounceCurrentSelection();
+                        return true;
+                    }
+                    currentDialog.Close(doCloseSound: false);
+                    TolkHelper.Speak("Entity Codex closed.");
+                    return true;
+
+                case KeyCode.Backspace:
+                    if (typeaheadHelper.HasActiveSearch)
+                    {
+                        var labelsBack = GetEntryLabels();
+                        if (typeaheadHelper.ProcessBackspace(labelsBack, out int backIdx))
+                        {
+                            selectedIndex = backIdx;
+                            AnnounceWithSearch();
+                        }
+                        else
+                        {
+                            AnnounceCurrentSelection();
+                        }
+                    }
+                    return true;
+
+                case KeyCode.UpArrow:
+                    if (typeaheadHelper.HasActiveSearch && !typeaheadHelper.HasNoMatches)
+                    {
+                        int prev = typeaheadHelper.GetPreviousMatch(selectedIndex);
+                        if (prev >= 0) selectedIndex = prev;
+                        AnnounceWithSearch();
+                    }
+                    else if (allEntries.Count > 0)
+                    {
+                        selectedIndex = MenuHelper.SelectPrevious(selectedIndex, allEntries.Count);
+                        AnnounceCurrentSelection();
+                    }
+                    return true;
+
+                case KeyCode.DownArrow:
+                    if (typeaheadHelper.HasActiveSearch && !typeaheadHelper.HasNoMatches)
+                    {
+                        int next = typeaheadHelper.GetNextMatch(selectedIndex);
+                        if (next >= 0) selectedIndex = next;
+                        AnnounceWithSearch();
+                    }
+                    else if (allEntries.Count > 0)
+                    {
+                        selectedIndex = MenuHelper.SelectNext(selectedIndex, allEntries.Count);
+                        AnnounceCurrentSelection();
+                    }
+                    return true;
+
+                case KeyCode.Return:
+                case KeyCode.KeypadEnter:
+                    AnnounceCurrentSelection();
+                    return true;
+
+                default:
+                    bool isLetter = key >= KeyCode.A && key <= KeyCode.Z;
+                    bool isNumber = key >= KeyCode.Alpha0 && key <= KeyCode.Alpha9;
+                    if (isLetter || isNumber)
+                    {
+                        TypeaheadCharacterBuffer.RequestCharacter(c =>
+                        {
+                            var labels = GetEntryLabels();
+                            if (typeaheadHelper.ProcessCharacterInput(c, labels, out int newIdx))
+                            {
+                                if (newIdx >= 0)
+                                {
+                                    selectedIndex = newIdx;
+                                    AnnounceWithSearch();
+                                }
+                            }
+                            else
+                            {
+                                TolkHelper.Speak($"No matches for '{typeaheadHelper.LastFailedSearch}'");
+                            }
+                        });
+                        return true;
+                    }
+                    return true; // Modal window: consume all unhandled keys.
+            }
+        }
+
+        private static void AnnounceCurrentSelection()
+        {
+            if (allEntries.Count == 0 || selectedIndex < 0 || selectedIndex >= allEntries.Count)
+                return;
+
+            string announcement = FormatEntryAnnouncement(selectedIndex);
+            string position = MenuHelper.FormatPosition(selectedIndex, allEntries.Count);
+
+            string fullText = string.IsNullOrEmpty(position)
+                ? announcement
+                : $"{announcement}, {position}";
+            TolkHelper.Speak(fullText, SpeechPriority.Normal);
+        }
+
+        private static void AnnounceWithSearch()
+        {
+            if (allEntries.Count == 0 || selectedIndex < 0 || selectedIndex >= allEntries.Count)
+                return;
+
+            if (!typeaheadHelper.HasActiveSearch)
+            {
+                AnnounceCurrentSelection();
+                return;
+            }
+
+            TolkHelper.Speak(
+                $"{FormatEntryAnnouncement(selectedIndex)}, {typeaheadHelper.CurrentMatchPosition} of {typeaheadHelper.MatchCount} matches for '{typeaheadHelper.SearchBuffer}'");
+        }
+
+        private static string FormatEntryAnnouncement(int index)
+        {
+            var entry = allEntries[index];
+            bool discovered = entry.Discovered;
+
+            var sb = new StringBuilder();
+
+            if (discovered)
+            {
+                sb.Append(entry.LabelCap.Resolve());
+                string category = entry.category?.LabelCap.Resolve();
+                if (!string.IsNullOrEmpty(category))
+                {
+                    sb.Append(", ");
+                    sb.Append(category);
+                }
+                sb.Append(". ");
+                sb.Append(SanitizeText(entry.Description));
+
+                if (entry.linkedThings?.Count > 0)
+                {
+                    sb.Append(". ");
+                    sb.Append(string.Join(", ", entry.linkedThings.Select(t => t.LabelCap.ToString())));
+                    sb.Append(".");
+                }
+            }
+            else
+            {
+                sb.Append("UndiscoveredEntity".Translate().Resolve());
+                string category = entry.category?.LabelCap.Resolve();
+                if (!string.IsNullOrEmpty(category))
+                {
+                    sb.Append(", ");
+                    sb.Append(category);
+                }
+                sb.Append(". ");
+                sb.Append("UndiscoveredEntityDesc".Translate().Resolve());
+            }
+
+            return sb.ToString();
+        }
+
+        private static List<string> GetEntryLabels()
+        {
+            var labels = new List<string>(allEntries.Count);
+            string undiscoveredLabel = "UndiscoveredEntity".Translate().ToString();
+            foreach (var entry in allEntries)
+            {
+                labels.Add(entry.Discovered ? entry.LabelCap.ToString() : undiscoveredLabel);
+            }
+            return labels;
+        }
+
+        private static bool HasVisibleEntries(EntityCategoryDef cat)
+        {
+            return DefDatabase<EntityCodexEntryDef>.AllDefsListForReading
+                .Any(e => e.Visible && e.category == cat);
+        }
+
+        private static string SanitizeText(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return "";
+            return text.Replace("\n\n", ". ").Replace("\n", " ").Trim();
+        }
+    }
+}

--- a/src/Anomaly/EntityCodexState.cs
+++ b/src/Anomaly/EntityCodexState.cs
@@ -16,6 +16,8 @@ namespace RimWorldAccess
         private static int selectedIndex;
         private static TypeaheadSearchHelper typeaheadHelper = new TypeaheadSearchHelper();
 
+        private static System.Reflection.FieldInfo selectedEntryField;
+
         public static bool IsActive => isActive;
         public static bool HasActiveSearch => typeaheadHelper.HasActiveSearch;
 
@@ -26,24 +28,40 @@ namespace RimWorldAccess
 
             try
             {
+                if (selectedEntryField == null)
+                    selectedEntryField = HarmonyLib.AccessTools.Field(typeof(Dialog_EntityCodex), "selectedEntry");
+
                 currentDialog = dialog;
                 typeaheadHelper.ClearSearch();
                 selectedIndex = 0;
 
-                // Build flat entry list ordered by category listOrder, then orderInCategory, then label.
+                // Match vanilla sort: (orderInCategory, label). Dialog_EntityCodex uses .label, not .LabelCap.
                 allEntries = DefDatabase<EntityCategoryDef>.AllDefsListForReading
                     .Where(HasVisibleEntries)
                     .OrderBy(c => c.listOrder)
                     .SelectMany(c => DefDatabase<EntityCodexEntryDef>.AllDefsListForReading
                         .Where(e => e.Visible && e.category == c)
                         .OrderBy(e => e.orderInCategory)
-                        .ThenBy(e => e.LabelCap.ToString()))
+                        .ThenBy(e => e.label))
                     .ToList();
+
+                // Seed selected index from the dialog's selectedEntry so "View entity codex" letter
+                // actions and other pre-selected opens land on the correct entry.
+                var dialogSelected = selectedEntryField?.GetValue(dialog) as EntityCodexEntryDef;
+                if (dialogSelected != null)
+                {
+                    int idx = allEntries.IndexOf(dialogSelected);
+                    if (idx >= 0) selectedIndex = idx;
+                }
 
                 isActive = true;
 
                 string title = "EntityCodex".Translate().Resolve();
                 TolkHelper.Speak($"{title}. {allEntries.Count} entries.", SpeechPriority.Normal);
+
+                string desc = "EntityCodexDesc".Translate().Resolve();
+                if (!string.IsNullOrEmpty(desc))
+                    TolkHelper.Speak(SanitizeText(desc), SpeechPriority.Normal);
 
                 if (allEntries.Count > 0)
                     AnnounceCurrentSelection();
@@ -97,8 +115,9 @@ namespace RimWorldAccess
                         AnnounceCurrentSelection();
                         return true;
                     }
+                    // PostClose patch speaks the close announcement so X-button and Close-button
+                    // paths also announce.
                     currentDialog.Close(doCloseSound: false);
-                    TolkHelper.Speak("Entity Codex closed.");
                     return true;
 
                 case KeyCode.Backspace:
@@ -227,8 +246,23 @@ namespace RimWorldAccess
 
                 if (entry.linkedThings?.Count > 0)
                 {
+                    string undiscoveredItem = "Undiscovered".Translate().Resolve();
+                    var codex = Find.EntityCodex;
+                    var linkedLabels = entry.linkedThings.Select(t =>
+                        (codex != null && codex.Discovered(t))
+                            ? t.LabelCap.ToString()
+                            : undiscoveredItem);
                     sb.Append(". ");
-                    sb.Append(string.Join(", ", entry.linkedThings.Select(t => t.LabelCap.ToString())));
+                    sb.Append(string.Join(", ", linkedLabels));
+                    sb.Append(".");
+                }
+
+                if (entry.discoveredResearchProjects?.Count > 0)
+                {
+                    sb.Append(" ");
+                    sb.Append("ResearchUnlocks".Translate().Resolve());
+                    sb.Append(": ");
+                    sb.Append(string.Join(", ", entry.discoveredResearchProjects.Select(r => r.LabelCap.ToString())));
                     sb.Append(".");
                 }
             }

--- a/src/Input/UnifiedKeyboardPatch.cs
+++ b/src/Input/UnifiedKeyboardPatch.cs
@@ -2827,6 +2827,16 @@ namespace RimWorldAccess
                 }
             }
 
+            // ===== PRIORITY 4.64: Handle entity codex dialog if active =====
+            if (EntityCodexState.IsActive)
+            {
+                if (EntityCodexState.HandleInput(Event.current))
+                {
+                    Event.current.Use();
+                    return;
+                }
+            }
+
             // ===== PRIORITY 4.7: Handle research menu if active =====
             if (WindowlessResearchMenuState.IsActive)
             {


### PR DESCRIPTION
Adds screen reader support for `Dialog_EntityCodex` (Anomaly DLC). The codex was entirely inaccessible — it is a custom `Window` subclass with no `Dialog_NodeTree` base, so `WindowlessDialogState` never intercepted it.

`EntityCodexState` builds a flat list of all visible `EntityCodexEntryDef` entries ordered by category `listOrder` then `orderInCategory`. Navigation uses Up/Down/Home/End with typeahead search via `TypeaheadSearchHelper`. Discovered entries announce their label, category, description, and linked things; undiscovered entries use translated `UndiscoveredEntity`/`UndiscoveredEntityDesc` strings.

`EntityCodexPatch` hooks `Window.PostOpen`, `Window.PostClose`, and `Window.OnCancelKeyPressed` following the same three-patch pattern as `DryadCastePatch`. The state is wired into `UnifiedKeyboardPatch` at priority 4.64 (between the options menu at 4.6 and the research menu at 4.7).

The two `Dialog_NodeTree` dialogs the monolith triggers (investigate and activated) were already handled by `WindowlessDialogState` and required no changes.
