### PR TITLE
feat(map): add unexplored fog areas to environmental scanner

### DIFF
--- a/src/Map/FogChangePatch.cs
+++ b/src/Map/FogChangePatch.cs
@@ -3,16 +3,18 @@ using Verse;
 
 namespace RimWorldAccess
 {
+    /// <summary>
+    /// Marks the scanner's cell-walk cache dirty whenever a cell's fog state changes,
+    /// so the next scanner navigation refreshes the Unexplored category (and the rest
+    /// of the cell-derived categories that share the same walk).
+    /// </summary>
+    [HarmonyPatch(typeof(MapEvents), "Notify_CellFogChanged")]
     public static class FogChangePatch
     {
-        [HarmonyPatch(typeof(MapEvents), "Notify_CellFogChanged")]
-        public static class MapEvents_CellFogChanged_Patch
+        [HarmonyPostfix]
+        public static void Postfix()
         {
-            [HarmonyPostfix]
-            public static void Postfix()
-            {
-                ScannerHelper.FogDirty = true;
-            }
+            ScannerHelper.MarkFogDirty();
         }
     }
 }

--- a/src/Map/FogChangePatch.cs
+++ b/src/Map/FogChangePatch.cs
@@ -1,0 +1,18 @@
+using HarmonyLib;
+using Verse;
+
+namespace RimWorldAccess
+{
+    public static class FogChangePatch
+    {
+        [HarmonyPatch(typeof(MapEvents), "Notify_CellFogChanged")]
+        public static class MapEvents_CellFogChanged_Patch
+        {
+            [HarmonyPostfix]
+            public static void Postfix()
+            {
+                ScannerHelper.FogDirty = true;
+            }
+        }
+    }
+}

--- a/src/Map/ScannerCategorySchema.cs
+++ b/src/Map/ScannerCategorySchema.cs
@@ -149,6 +149,7 @@ namespace RimWorldAccess
                 "Cut", "Harvest", "Smooth", "Tame", "Slaughter", "Other"),
             new ScannerCategorySchema("Zones", "Growing", "Stockpile", "Fishing", "Other"),
             new ScannerCategorySchema("Rooms"), // only gets "All"
+            new ScannerCategorySchema("Unexplored"),
             // Uncategorized is built separately — its subcategories are discovered at runtime.
         };
     }

--- a/src/Map/ScannerHelper.cs
+++ b/src/Map/ScannerHelper.cs
@@ -446,6 +446,12 @@ namespace RimWorldAccess
 
     public static class ScannerHelper
     {
+        // Shared label for fog-of-war items in the Unexplored category. Search excludes items
+        // with this label since every fog region carries the same name and would dominate
+        // results. Used by both CollectMapItems (when emitting fog items) and the search
+        // filter so they stay in sync.
+        public const string UnexploredAreaLabel = "unexplored area";
+
         /// <summary>
         /// Adds a ScannerItem to both its specialized subcategory AND the category's "All"
         /// subcategory (convention: Subcategories[0]). This is the standard pattern used by
@@ -778,10 +784,13 @@ namespace RimWorldAccess
                 }
             }
 
-            // Collect mineable tiles, terrain, and deep ore in a single pass over all cells
+            // Collect mineable tiles, terrain, deep ore, and fog cells in a single pass
+            // over all cells. The cache is invalidated on building changes (cell hash) OR on
+            // any fog state change — fog collection shares this walk, so all four categories
+            // refresh together.
             int currentCellHash = map.listerThings.StateHashOfGroup(ThingRequestGroup.BuildingArtificial);
 
-            if (cachedTerrainNatural != null && currentCellHash == lastCellHash && !FogDirty)
+            if (cachedTerrainNatural != null && currentCellHash == lastCellHash && !fogDirty)
             {
                 // Reuse cached cell data — skip 60K+ cell iteration entirely.
                 // Also mirror every cached item into the category's "All" subcategory.
@@ -790,14 +799,13 @@ namespace RimWorldAccess
                 mineableRareSubcat.Items.AddRange(cachedMineableRare);
                 mineableStoneSubcat.Items.AddRange(cachedMineableStone);
                 mineableScannedSubcat.Items.AddRange(cachedMineableScanned);
+                unexploredCategory.Subcategories[0].Items.AddRange(cachedFogItems);
 
                 terrainCategory.Subcategories[0].Items.AddRange(cachedTerrainNatural);
                 terrainCategory.Subcategories[0].Items.AddRange(cachedTerrainConstructed);
                 mineableCategory.Subcategories[0].Items.AddRange(cachedMineableRare);
                 mineableCategory.Subcategories[0].Items.AddRange(cachedMineableStone);
                 mineableCategory.Subcategories[0].Items.AddRange(cachedMineableScanned);
-                if (cachedFogItems != null)
-                    unexploredCategory.Subcategories[0].Items.AddRange(cachedFogItems);
             }
             else
             {
@@ -808,7 +816,7 @@ namespace RimWorldAccess
                 // Collect mineables by def type for later adjacency grouping
                 var mineableRareByDef = new Dictionary<string, List<(IntVec3 position, Thing thing)>>();
                 var mineableStoneByDef = new Dictionary<string, List<(IntVec3 position, Thing thing)>>();
-                var fogCellItems = new List<ScannerItem>();
+                var fogPositions = new List<IntVec3>();
 
                 foreach (var cell in allCells)
                 {
@@ -877,7 +885,7 @@ namespace RimWorldAccess
                     }
                     else
                     {
-                        fogCellItems.Add(new ScannerItem(cell, "unexplored area", cursorPosition));
+                        fogPositions.Add(cell);
                     }
 
                     // Collect deep ore in same pass (only if active scanner exists)
@@ -942,17 +950,28 @@ namespace RimWorldAccess
                     }
                 }
 
+                // Group unexplored fog cells by adjacency. Each contiguous fog region becomes
+                // its own scanner item so users can navigate region-by-region. This matches the
+                // game's data model: FogGrid is a sibling of TerrainGrid on Map, not a property
+                // of terrain, so each fog blob is treated as a first-class navigable item.
+                // Unexplored has only an "All" subcategory, so add directly (AddTo would
+                // double-add since specialized == Subcategories[0]).
+                var fogRegions = GroupTerrainByAdjacency(fogPositions, cursorPosition);
+                foreach (var region in fogRegions)
+                {
+                    var fogItem = new ScannerItem(
+                        new List<TerrainRegion> { region }, UnexploredAreaLabel, cursorPosition);
+                    unexploredCategory.Subcategories[0].Items.Add(fogItem);
+                }
+
                 // Save results to cell cache
                 cachedTerrainNatural = new List<ScannerItem>(terrainNaturalSubcat.Items);
                 cachedTerrainConstructed = new List<ScannerItem>(terrainConstructedSubcat.Items);
                 cachedMineableRare = new List<ScannerItem>(mineableRareSubcat.Items);
                 cachedMineableStone = new List<ScannerItem>(mineableStoneSubcat.Items);
                 cachedMineableScanned = new List<ScannerItem>(mineableScannedSubcat.Items);
-
-                // Add fog cells to unexplored category and cache them
-                unexploredCategory.Subcategories[0].Items.AddRange(fogCellItems);
-                cachedFogItems = fogCellItems;
-                FogDirty = false;
+                cachedFogItems = new List<ScannerItem>(unexploredCategory.Subcategories[0].Items);
+                fogDirty = false;
 
                 lastCellHash = currentCellHash;
             }
@@ -1481,8 +1500,16 @@ namespace RimWorldAccess
         private static List<ScannerItem> cachedMineableStone = null;
         private static List<ScannerItem> cachedMineableScanned = null;
         private static List<ScannerItem> cachedFogItems = null;
-        public static bool FogDirty = true;
+        private static bool fogDirty = true;
         private static int lastCellHash = 0;
+
+        /// <summary>
+        /// Invalidates the fog portion of the cell-walk cache. Called by FogChangePatch
+        /// whenever a cell's fog state changes. The next CollectMapItems will rebuild the
+        /// Unexplored category — and, because fog collection shares the AllCells walk with
+        /// terrain/mineables/deep ore, those caches are rebuilt at the same time.
+        /// </summary>
+        public static void MarkFogDirty() => fogDirty = true;
 
         /// <summary>
         /// Invalidates all cell-based caches. Call when the map state changes
@@ -1496,7 +1523,7 @@ namespace RimWorldAccess
             cachedMineableStone = null;
             cachedMineableScanned = null;
             cachedFogItems = null;
-            FogDirty = true;
+            fogDirty = true;
             lastCellHash = 0;
             designatorLabelCache = null;
         }

--- a/src/Map/ScannerHelper.cs
+++ b/src/Map/ScannerHelper.cs
@@ -546,6 +546,7 @@ namespace RimWorldAccess
             var zonesOtherSubcat = buckets.Sub("Zones-Other");
 
             var roomsCategory = buckets.Cat("Rooms");
+            var unexploredCategory = buckets.Cat("Unexplored");
 
             // Uncategorized category — dict of per-def subcategories. The "All" subcategory
             // at index 0 was inserted by BuildFromSchema.
@@ -780,7 +781,7 @@ namespace RimWorldAccess
             // Collect mineable tiles, terrain, and deep ore in a single pass over all cells
             int currentCellHash = map.listerThings.StateHashOfGroup(ThingRequestGroup.BuildingArtificial);
 
-            if (cachedTerrainNatural != null && currentCellHash == lastCellHash)
+            if (cachedTerrainNatural != null && currentCellHash == lastCellHash && !FogDirty)
             {
                 // Reuse cached cell data — skip 60K+ cell iteration entirely.
                 // Also mirror every cached item into the category's "All" subcategory.
@@ -795,6 +796,8 @@ namespace RimWorldAccess
                 mineableCategory.Subcategories[0].Items.AddRange(cachedMineableRare);
                 mineableCategory.Subcategories[0].Items.AddRange(cachedMineableStone);
                 mineableCategory.Subcategories[0].Items.AddRange(cachedMineableScanned);
+                if (cachedFogItems != null)
+                    unexploredCategory.Subcategories[0].Items.AddRange(cachedFogItems);
             }
             else
             {
@@ -805,6 +808,7 @@ namespace RimWorldAccess
                 // Collect mineables by def type for later adjacency grouping
                 var mineableRareByDef = new Dictionary<string, List<(IntVec3 position, Thing thing)>>();
                 var mineableStoneByDef = new Dictionary<string, List<(IntVec3 position, Thing thing)>>();
+                var fogCellItems = new List<ScannerItem>();
 
                 foreach (var cell in allCells)
                 {
@@ -870,6 +874,10 @@ namespace RimWorldAccess
                                 }
                             }
                         }
+                    }
+                    else
+                    {
+                        fogCellItems.Add(new ScannerItem(cell, "unexplored area", cursorPosition));
                     }
 
                     // Collect deep ore in same pass (only if active scanner exists)
@@ -940,6 +948,12 @@ namespace RimWorldAccess
                 cachedMineableRare = new List<ScannerItem>(mineableRareSubcat.Items);
                 cachedMineableStone = new List<ScannerItem>(mineableStoneSubcat.Items);
                 cachedMineableScanned = new List<ScannerItem>(mineableScannedSubcat.Items);
+
+                // Add fog cells to unexplored category and cache them
+                unexploredCategory.Subcategories[0].Items.AddRange(fogCellItems);
+                cachedFogItems = fogCellItems;
+                FogDirty = false;
+
                 lastCellHash = currentCellHash;
             }
 
@@ -1466,6 +1480,8 @@ namespace RimWorldAccess
         private static List<ScannerItem> cachedMineableRare = null;
         private static List<ScannerItem> cachedMineableStone = null;
         private static List<ScannerItem> cachedMineableScanned = null;
+        private static List<ScannerItem> cachedFogItems = null;
+        public static bool FogDirty = true;
         private static int lastCellHash = 0;
 
         /// <summary>
@@ -1479,6 +1495,8 @@ namespace RimWorldAccess
             cachedMineableRare = null;
             cachedMineableStone = null;
             cachedMineableScanned = null;
+            cachedFogItems = null;
+            FogDirty = true;
             lastCellHash = 0;
             designatorLabelCache = null;
         }

--- a/src/Map/ScannerSearchState.cs
+++ b/src/Map/ScannerSearchState.cs
@@ -296,7 +296,9 @@ namespace RimWorldAccess
             if (string.IsNullOrEmpty(activeFilterQuery) || activeFilterIsWorldMap)
                 return null;
 
-            var allItems = FlattenFromAllCategory(preCollectedCategories);
+            var allItems = FlattenFromAllCategory(preCollectedCategories)
+                .Where(item => item.Label != ScannerHelper.UnexploredAreaLabel)
+                .ToList();
 
             return ScannerSearchEngine.FilterAndRank(
                 allItems, activeFilterQuery, item => item.Label, item => item.Distance);
@@ -382,8 +384,11 @@ namespace RimWorldAccess
 
             var cursor = MapNavigationState.CurrentCursorPosition;
 
-            // Collect all items from all categories
-            var allItems = CollectAllMapItemsFlat(map, cursor);
+            // Collect all items from all categories. Fog-of-war regions all share the same
+            // "unexplored area" label, so exclude them from search to avoid noise.
+            var allItems = CollectAllMapItemsFlat(map, cursor)
+                .Where(item => item.Label != ScannerHelper.UnexploredAreaLabel)
+                .ToList();
 
             var matching = ScannerSearchEngine.FilterAndRank(
                 allItems, searchBuffer, item => item.Label, item => item.Distance);


### PR DESCRIPTION
Adds an "Unexplored" category to the environmental scanner (PageUp/PageDown) so screen reader users can locate fog-of-war regions on the map.

Fogged cells are collected during the existing `AllCells` pass in `CollectMapItems` and grouped into contiguous regions via the same `GroupTerrainByAdjacency` flood-fill already used for terrain and mineables. Each region announces as e.g. "unexplored area: 42 tiles, 15.2 tiles northeast, area 2 of 7".

`FogChangePatch` hooks `MapEvents.Notify_CellFogChanged` to set a dirty flag whenever a cell's fog state changes. The Unexplored category re-collects on the next navigation keypress rather than serving stale data from before the pawn explored. All other scanner categories are unaffected by the dirty flag.
