### PR TITLE
feat: add mouse exploration for map and world navigation

### DIFF
--- a/src/Input/MapArrowKeyHandler.cs
+++ b/src/Input/MapArrowKeyHandler.cs
@@ -22,6 +22,8 @@ namespace RimWorldAccess
         /// <returns>True if the key was handled, false otherwise</returns>
         public static bool HandleArrowKey(KeyCode key, bool ctrlHeld, bool shiftHeld)
         {
+            MapNavigationPatch.NotifyArrowKeyNavigation();
+
             // Handle Shift+arrow for jump mode adjustments.
             // Shift+Up/Down cycles jump modes; Shift+Left/Right adjusts preset distance.
             // These adjustments must NEVER move the cursor or camera — the user is only

--- a/src/Input/UnifiedKeyboardPatch.cs
+++ b/src/Input/UnifiedKeyboardPatch.cs
@@ -6733,6 +6733,27 @@ namespace RimWorldAccess
 
             // ===== PRIORITY 10.5: Handle local map arrow key navigation =====
             // Uses Event.current for OS key repeat support (unlike CameraDriver.Update() which uses Input.GetKeyDown)
+            if (key == KeyCode.M && Event.current.shift && !Event.current.control && !Event.current.alt)
+            {
+                if (WorldRendererUtility.WorldRendered)
+                    return;
+
+                if (Current.ProgramState != ProgramState.Playing || Find.CurrentMap == null)
+                    return;
+
+                if (Find.WindowStack?.WindowsPreventCameraMotion == true)
+                    return;
+
+                if (!MapNavigationState.IsInitialized || MapNavigationState.SuppressMapNavigation)
+                    return;
+
+                if (MapNavigationPatch.MoveCursorToLastMouseCell())
+                {
+                    Event.current.Use();
+                }
+                return;
+            }
+
             if (key == KeyCode.UpArrow || key == KeyCode.DownArrow ||
                 key == KeyCode.LeftArrow || key == KeyCode.RightArrow)
             {

--- a/src/Input/UnifiedKeyboardPatch.cs
+++ b/src/Input/UnifiedKeyboardPatch.cs
@@ -6729,6 +6729,27 @@ namespace RimWorldAccess
 
             // ===== PRIORITY 10.5: Handle local map arrow key navigation =====
             // Uses Event.current for OS key repeat support (unlike CameraDriver.Update() which uses Input.GetKeyDown)
+            if (key == KeyCode.M && Event.current.shift && !Event.current.control && !Event.current.alt)
+            {
+                if (WorldRendererUtility.WorldRendered)
+                    return;
+
+                if (Current.ProgramState != ProgramState.Playing || Find.CurrentMap == null)
+                    return;
+
+                if (Find.WindowStack?.WindowsPreventCameraMotion == true)
+                    return;
+
+                if (!MapNavigationState.IsInitialized || MapNavigationState.SuppressMapNavigation)
+                    return;
+
+                if (MapNavigationPatch.MoveCursorToLastMouseCell())
+                {
+                    Event.current.Use();
+                }
+                return;
+            }
+
             if (key == KeyCode.UpArrow || key == KeyCode.DownArrow ||
                 key == KeyCode.LeftArrow || key == KeyCode.RightArrow)
             {

--- a/src/Map/MapNavigationPatch.cs
+++ b/src/Map/MapNavigationPatch.cs
@@ -18,6 +18,9 @@ namespace RimWorldAccess
     {
         private static bool hasAnnouncedThisFrame = false;
         private static int lastProcessedFrame = -1;
+        private static IntVec3 lastMouseCell = IntVec3.Invalid;
+        private static int lastMouseCellMapId = -1;
+        private static float lastArrowKeyPressTime = 0f;
 
         /// <summary>
         /// Updates the map navigation suppression flag based on active menus.
@@ -110,6 +113,8 @@ namespace RimWorldAccess
             if (Find.CurrentMap == null)
             {
                 MapNavigationState.Reset();
+                lastMouseCell = IntVec3.Invalid;
+                lastMouseCellMapId = -1;
                 return true; // Let original run
             }
 
@@ -182,10 +187,91 @@ namespace RimWorldAccess
             // - Frame deduplication
             // - Map changes check and initialization
             // - Map switching with Shift+comma/period
+            // - Mouse exploration announcements while holding Left Shift
+
+            if (!MapNavigationState.SuppressMapNavigation && Find.CurrentMap != null)
+            {
+                bool shiftHeldForMouse = Input.GetKey(KeyCode.LeftShift);
+
+                if (shiftHeldForMouse)
+                {
+                    IntVec3 mouseCell = UI.MouseCell();
+                    if (mouseCell.InBounds(Find.CurrentMap))
+                    {
+                        bool mouseCellChanged = mouseCell != lastMouseCell || Find.CurrentMap.uniqueID != lastMouseCellMapId;
+                        float timeSinceArrowKey = Time.time - lastArrowKeyPressTime;
+                        bool keyboardIdle = timeSinceArrowKey > 0.5f;
+
+                        if (mouseCellChanged && keyboardIdle)
+                        {
+                            string tileInfo = TileInfoHelper.GetTileSummary(mouseCell, Find.CurrentMap);
+
+                            if (ZoneCreationState.IsInCreationMode)
+                            {
+                                if (ZoneCreationState.IsInPreviewMode && ZoneCreationState.PreviewCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Preview, " + tileInfo;
+                                }
+                                else if (ZoneCreationState.IsCellSelected(mouseCell))
+                                {
+                                    tileInfo = "Selected, " + tileInfo;
+                                }
+                            }
+                            else if (AreaPaintingState.IsActive)
+                            {
+                                if (AreaPaintingState.IsInPreviewMode && AreaPaintingState.PreviewCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Preview, " + tileInfo;
+                                }
+                                else if (AreaPaintingState.StagedCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Selected, " + tileInfo;
+                                }
+                            }
+                            else if (ArchitectState.IsInPlacementMode && ArchitectState.IsZoneDesignator())
+                            {
+                                if (ArchitectState.IsInPreviewMode && ArchitectState.PreviewCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Preview, " + tileInfo;
+                                }
+                                else if (ArchitectState.SelectedCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Selected, " + tileInfo;
+                                }
+                            }
+
+                            if (tileInfo != MapNavigationState.LastAnnouncedInfo)
+                            {
+                                TolkHelper.Speak(tileInfo, SpeechPriority.High);
+                                MapNavigationState.LastAnnouncedInfo = tileInfo;
+                                hasAnnouncedThisFrame = true;
+                            }
+
+                            lastMouseCell = mouseCell;
+                            lastMouseCellMapId = Find.CurrentMap.uniqueID;
+                        }
+                    }
+                    else if (lastMouseCell.IsValid || lastMouseCellMapId != -1)
+                    {
+                        lastMouseCell = IntVec3.Invalid;
+                        lastMouseCellMapId = -1;
+                    }
+                }
+                else if (lastMouseCell.IsValid || lastMouseCellMapId != -1)
+                {
+                    lastMouseCell = IntVec3.Invalid;
+                    lastMouseCellMapId = -1;
+                }
+            }
 
             // Let original CameraDriver.Update() run for non-arrow-key functionality
             // (zoom, following, etc.)
             return true;
+        }
+
+        public static void NotifyArrowKeyNavigation()
+        {
+            lastArrowKeyPressTime = Time.time;
         }
 
         /// <summary>

--- a/src/Map/MapNavigationPatch.cs
+++ b/src/Map/MapNavigationPatch.cs
@@ -228,11 +228,19 @@ namespace RimWorldAccess
                                     tileInfo = "Selected, " + tileInfo;
                                 }
                             }
-                            else if (ArchitectState.IsInPlacementMode && ArchitectState.IsZoneDesignator())
+                            else if (ArchitectState.IsInPlacementMode)
                             {
-                                if (ArchitectState.IsInPreviewMode && ArchitectState.PreviewCells.Contains(mouseCell))
+                                if (ShapePlacementState.IsActive && ShapePlacementState.PreviewCells.Contains(mouseCell))
                                 {
-                                    tileInfo = "Preview, " + tileInfo;
+                                    if (ShapePlacementState.FirstPoint.HasValue && mouseCell == ShapePlacementState.FirstPoint.Value)
+                                    {
+                                        tileInfo = "First point, " + tileInfo;
+                                    }
+                                    else if (ShapePlacementState.CurrentPhase == PlacementPhase.Previewing &&
+                                             ShapePlacementState.SecondPoint.HasValue && mouseCell == ShapePlacementState.SecondPoint.Value)
+                                    {
+                                        tileInfo = "Second point, " + tileInfo;
+                                    }
                                 }
                                 else if (ArchitectState.SelectedCells.Contains(mouseCell))
                                 {

--- a/src/Map/MapNavigationPatch.cs
+++ b/src/Map/MapNavigationPatch.cs
@@ -283,6 +283,31 @@ namespace RimWorldAccess
         }
 
         /// <summary>
+        /// Moves the keyboard cursor to the last valid cell discovered by mouse exploration.
+        /// Returns true if the cursor was moved.
+        /// </summary>
+        public static bool MoveCursorToLastMouseCell()
+        {
+            if (Find.CurrentMap == null || !lastMouseCell.IsValid || lastMouseCellMapId != Find.CurrentMap.uniqueID)
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return false;
+            }
+
+            if (!lastMouseCell.InBounds(Find.CurrentMap))
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return false;
+            }
+
+            MapNavigationState.CurrentCursorPosition = lastMouseCell;
+            MapNavigationState.CurrentCameraMode = CameraFollowMode.Cursor;
+            Find.CameraDriver?.JumpToCurrentMapLoc(lastMouseCell);
+            MapArrowKeyHandler.AnnouncePosition(lastMouseCell, Find.CurrentMap);
+            return true;
+        }
+
+        /// <summary>
         /// Handles switching between maps when Shift+comma or Shift+period is pressed.
         /// Restores cursor to last known position on the target map.
         /// </summary>

--- a/src/Map/MapNavigationPatch.cs
+++ b/src/Map/MapNavigationPatch.cs
@@ -293,6 +293,31 @@ namespace RimWorldAccess
         }
 
         /// <summary>
+        /// Moves the keyboard cursor to the last valid cell discovered by mouse exploration.
+        /// Returns true if the cursor was moved.
+        /// </summary>
+        public static bool MoveCursorToLastMouseCell()
+        {
+            if (Find.CurrentMap == null || !lastMouseCell.IsValid || lastMouseCellMapId != Find.CurrentMap.uniqueID)
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return false;
+            }
+
+            if (!lastMouseCell.InBounds(Find.CurrentMap))
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return false;
+            }
+
+            MapNavigationState.CurrentCursorPosition = lastMouseCell;
+            MapNavigationState.CurrentCameraMode = CameraFollowMode.Cursor;
+            Find.CameraDriver?.JumpToCurrentMapLoc(lastMouseCell);
+            MapArrowKeyHandler.AnnouncePosition(lastMouseCell, Find.CurrentMap);
+            return true;
+        }
+
+        /// <summary>
         /// Handles switching between maps when Shift+comma or Shift+period is pressed.
         /// Restores cursor to last known position on the target map.
         /// </summary>

--- a/src/Map/MapNavigationPatch.cs
+++ b/src/Map/MapNavigationPatch.cs
@@ -238,11 +238,19 @@ namespace RimWorldAccess
                                     tileInfo = "Selected, " + tileInfo;
                                 }
                             }
-                            else if (ArchitectState.IsInPlacementMode && ArchitectState.IsZoneDesignator())
+                            else if (ArchitectState.IsInPlacementMode)
                             {
-                                if (ArchitectState.IsInPreviewMode && ArchitectState.PreviewCells.Contains(mouseCell))
+                                if (ShapePlacementState.IsActive && ShapePlacementState.PreviewCells.Contains(mouseCell))
                                 {
-                                    tileInfo = "Preview, " + tileInfo;
+                                    if (ShapePlacementState.FirstPoint.HasValue && mouseCell == ShapePlacementState.FirstPoint.Value)
+                                    {
+                                        tileInfo = "First point, " + tileInfo;
+                                    }
+                                    else if (ShapePlacementState.CurrentPhase == PlacementPhase.Previewing &&
+                                             ShapePlacementState.SecondPoint.HasValue && mouseCell == ShapePlacementState.SecondPoint.Value)
+                                    {
+                                        tileInfo = "Second point, " + tileInfo;
+                                    }
                                 }
                                 else if (ArchitectState.SelectedCells.Contains(mouseCell))
                                 {

--- a/src/Map/MapNavigationPatch.cs
+++ b/src/Map/MapNavigationPatch.cs
@@ -18,6 +18,9 @@ namespace RimWorldAccess
     {
         private static bool hasAnnouncedThisFrame = false;
         private static int lastProcessedFrame = -1;
+        private static IntVec3 lastMouseCell = IntVec3.Invalid;
+        private static int lastMouseCellMapId = -1;
+        private static float lastArrowKeyPressTime = 0f;
 
         /// <summary>
         /// Updates the map navigation suppression flag based on active menus.
@@ -120,6 +123,8 @@ namespace RimWorldAccess
             if (Find.CurrentMap == null)
             {
                 MapNavigationState.Reset();
+                lastMouseCell = IntVec3.Invalid;
+                lastMouseCellMapId = -1;
                 return true; // Let original run
             }
 
@@ -192,10 +197,91 @@ namespace RimWorldAccess
             // - Frame deduplication
             // - Map changes check and initialization
             // - Map switching with Shift+comma/period
+            // - Mouse exploration announcements while holding Left Shift
+
+            if (!MapNavigationState.SuppressMapNavigation && Find.CurrentMap != null)
+            {
+                bool shiftHeldForMouse = Input.GetKey(KeyCode.LeftShift);
+
+                if (shiftHeldForMouse)
+                {
+                    IntVec3 mouseCell = UI.MouseCell();
+                    if (mouseCell.InBounds(Find.CurrentMap))
+                    {
+                        bool mouseCellChanged = mouseCell != lastMouseCell || Find.CurrentMap.uniqueID != lastMouseCellMapId;
+                        float timeSinceArrowKey = Time.time - lastArrowKeyPressTime;
+                        bool keyboardIdle = timeSinceArrowKey > 0.5f;
+
+                        if (mouseCellChanged && keyboardIdle)
+                        {
+                            string tileInfo = TileInfoHelper.GetTileSummary(mouseCell, Find.CurrentMap);
+
+                            if (ZoneCreationState.IsInCreationMode)
+                            {
+                                if (ZoneCreationState.IsInPreviewMode && ZoneCreationState.PreviewCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Preview, " + tileInfo;
+                                }
+                                else if (ZoneCreationState.IsCellSelected(mouseCell))
+                                {
+                                    tileInfo = "Selected, " + tileInfo;
+                                }
+                            }
+                            else if (AreaPaintingState.IsActive)
+                            {
+                                if (AreaPaintingState.IsInPreviewMode && AreaPaintingState.PreviewCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Preview, " + tileInfo;
+                                }
+                                else if (AreaPaintingState.StagedCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Selected, " + tileInfo;
+                                }
+                            }
+                            else if (ArchitectState.IsInPlacementMode && ArchitectState.IsZoneDesignator())
+                            {
+                                if (ArchitectState.IsInPreviewMode && ArchitectState.PreviewCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Preview, " + tileInfo;
+                                }
+                                else if (ArchitectState.SelectedCells.Contains(mouseCell))
+                                {
+                                    tileInfo = "Selected, " + tileInfo;
+                                }
+                            }
+
+                            if (tileInfo != MapNavigationState.LastAnnouncedInfo)
+                            {
+                                TolkHelper.Speak(tileInfo, SpeechPriority.High);
+                                MapNavigationState.LastAnnouncedInfo = tileInfo;
+                                hasAnnouncedThisFrame = true;
+                            }
+
+                            lastMouseCell = mouseCell;
+                            lastMouseCellMapId = Find.CurrentMap.uniqueID;
+                        }
+                    }
+                    else if (lastMouseCell.IsValid || lastMouseCellMapId != -1)
+                    {
+                        lastMouseCell = IntVec3.Invalid;
+                        lastMouseCellMapId = -1;
+                    }
+                }
+                else if (lastMouseCell.IsValid || lastMouseCellMapId != -1)
+                {
+                    lastMouseCell = IntVec3.Invalid;
+                    lastMouseCellMapId = -1;
+                }
+            }
 
             // Let original CameraDriver.Update() run for non-arrow-key functionality
             // (zoom, following, etc.)
             return true;
+        }
+
+        public static void NotifyArrowKeyNavigation()
+        {
+            lastArrowKeyPressTime = Time.time;
         }
 
         /// <summary>

--- a/src/World/WorldNavigationPatch.cs
+++ b/src/World/WorldNavigationPatch.cs
@@ -339,10 +339,10 @@ namespace RimWorldAccess
             if (!WorldNavigationState.IsActive || !WorldNavigationState.IsInitialized)
                 return;
 
-            // Check if left Ctrl is held down
-            bool ctrlHeldForMouse = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+            // Check if left Shift is held down to avoid screen reader Ctrl interruption
+            bool shiftHeldForMouse = Input.GetKey(KeyCode.LeftShift);
 
-            if (ctrlHeldForMouse)
+            if (shiftHeldForMouse)
             {
                 // Get current mouse tile on world map
                 int mouseTile = -1;
@@ -390,7 +390,7 @@ namespace RimWorldAccess
             }
             else
             {
-                // Ctrl is not held - reset tracking to ensure clean state
+                // Shift is not held - reset tracking to ensure clean state
                 if (lastWorldMouseTile != -1)
                 {
                     lastWorldMouseTile = -1;

--- a/src/World/WorldNavigationPatch.cs
+++ b/src/World/WorldNavigationPatch.cs
@@ -18,6 +18,10 @@ namespace RimWorldAccess
     {
         private static bool lastFrameWasWorldView = false;
 
+        // Mouse navigation tracking for world map
+        private static int lastWorldMouseTile = -1;
+        private static float lastWorldArrowKeyPressTime = 0f;
+
         /// <summary>
         /// Prefix patch that intercepts keyboard input for world map navigation.
         /// </summary>
@@ -85,6 +89,7 @@ namespace RimWorldAccess
                 key == KeyCode.LeftArrow || key == KeyCode.RightArrow)
             {
                 WorldNavigationState.HandleArrowKey(key);
+                lastWorldArrowKeyPressTime = Time.time;
                 Event.current.Use();
                 return;
             }
@@ -244,7 +249,7 @@ namespace RimWorldAccess
         }
 
         /// <summary>
-        /// Postfix patch to draw visual highlight on selected tile.
+        /// Postfix patch to draw visual highlight on selected tile and handle mouse navigation.
         /// </summary>
         [HarmonyPostfix]
         public static void Postfix()
@@ -264,6 +269,9 @@ namespace RimWorldAccess
 
             // For additional visual feedback, we could draw text overlay
             DrawTileInfoOverlay(selectedTile);
+
+            // Handle mouse navigation for automatic tile announcement on world map
+            HandleMouseNavigation();
         }
 
         /// <summary>
@@ -312,6 +320,82 @@ namespace RimWorldAccess
             // Reset text settings
             Text.Anchor = TextAnchor.UpperLeft;
             Text.Font = GameFont.Small;
+        }
+
+        /// <summary>
+        /// Handles mouse navigation for automatic tile announcement on world map.
+        /// </summary>
+        private static void HandleMouseNavigation()
+        {
+            // Skip if any accessibility menu is active
+            if (KeyboardHelper.IsAnyAccessibilityMenuActive())
+                return;
+
+            // Skip if caravan formation dialog is active (unless choosing destination)
+            if (CaravanFormationState.IsActive && !CaravanFormationState.IsChoosingDestination)
+                return;
+
+            // Skip if world navigation is not active or initialized
+            if (!WorldNavigationState.IsActive || !WorldNavigationState.IsInitialized)
+                return;
+
+            // Check if left Ctrl is held down
+            bool ctrlHeldForMouse = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+
+            if (ctrlHeldForMouse)
+            {
+                // Get current mouse tile on world map
+                int mouseTile = -1;
+                if (WorldRendererUtility.WorldRendered && Find.World != null)
+                {
+                    // Use screen position to get tile under mouse
+                    mouseTile = GenWorld.TileAt(UI.MousePositionOnUI, true);
+                }
+
+                // Check if mouse tile is valid
+                if (mouseTile < 0)
+                {
+                    // Mouse not over a valid tile, reset tracking
+                    if (lastWorldMouseTile != -1)
+                    {
+                        lastWorldMouseTile = -1;
+                    }
+                    return;
+                }
+
+                // Check if mouse moved to a new tile
+                bool mouseTileChanged = mouseTile != lastWorldMouseTile;
+
+                // Check time since last arrow key press (to avoid announcing when using keyboard)
+                float timeSinceArrowKey = Time.time - lastWorldArrowKeyPressTime;
+                bool keyboardIdle = timeSinceArrowKey > 0.5f; // 0.5 seconds threshold
+
+                if (mouseTileChanged && keyboardIdle)
+                {
+                    // Get tile information
+                    PlanetTile tile = new PlanetTile(mouseTile);
+                    string tileInfo = WorldInfoHelper.GetTileSummary(tile);
+
+                    // Announce tile info with interrupt to cut off previous speech
+                    TolkHelper.Speak(tileInfo, SpeechPriority.High);
+
+                    // Update mouse tracking
+                    lastWorldMouseTile = mouseTile;
+                }
+                else if (!mouseTileChanged && lastWorldMouseTile != -1)
+                {
+                    // Mouse is still on the same tile, no need to announce
+                    return;
+                }
+            }
+            else
+            {
+                // Ctrl is not held - reset tracking to ensure clean state
+                if (lastWorldMouseTile != -1)
+                {
+                    lastWorldMouseTile = -1;
+                }
+            }
         }
     }
 }

--- a/src/World/WorldNavigationPatch.cs
+++ b/src/World/WorldNavigationPatch.cs
@@ -147,6 +147,13 @@ namespace RimWorldAccess
                 return;
             }
 
+            if (key == KeyCode.M && shift && !ctrl && !alt)
+            {
+                MoveSelectionToLastMouseTile();
+                Event.current.Use();
+                return;
+            }
+
             // Note: Comma and Period keys for caravan cycling are handled in UnifiedKeyboardPatch
             // at a higher priority to prevent colonist selection from intercepting them
 
@@ -396,6 +403,40 @@ namespace RimWorldAccess
                     lastWorldMouseTile = -1;
                 }
             }
+        }
+
+        /// <summary>
+        /// Moves world navigation to the last valid tile discovered by mouse exploration.
+        /// </summary>
+        private static void MoveSelectionToLastMouseTile()
+        {
+            if (lastWorldMouseTile < 0)
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return;
+            }
+
+            PlanetTile tile = new PlanetTile(lastWorldMouseTile);
+            if (!tile.Valid)
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return;
+            }
+
+            WorldNavigationState.CurrentSelectedTile = tile;
+
+            if (Find.WorldSelector != null)
+            {
+                Find.WorldSelector.ClearSelection();
+                Find.WorldSelector.SelectedTile = tile;
+            }
+
+            if (Find.WorldCameraDriver != null)
+            {
+                Find.WorldCameraDriver.JumpTo(tile);
+            }
+
+            WorldNavigationState.AnnounceTile();
         }
     }
 }

--- a/src/World/WorldNavigationPatch.cs
+++ b/src/World/WorldNavigationPatch.cs
@@ -17,6 +17,10 @@ namespace RimWorldAccess
     {
         private static bool lastFrameWasWorldView = false;
 
+        // Mouse navigation tracking for world map
+        private static int lastWorldMouseTile = -1;
+        private static float lastWorldArrowKeyPressTime = 0f;
+
         /// <summary>
         /// Prefix patch that intercepts keyboard input for world map navigation.
         /// </summary>
@@ -84,6 +88,7 @@ namespace RimWorldAccess
                 key == KeyCode.LeftArrow || key == KeyCode.RightArrow)
             {
                 WorldNavigationState.HandleArrowKey(key);
+                lastWorldArrowKeyPressTime = Time.time;
                 Event.current.Use();
                 return;
             }
@@ -243,7 +248,7 @@ namespace RimWorldAccess
         }
 
         /// <summary>
-        /// Postfix patch to draw visual highlight on selected tile.
+        /// Postfix patch to draw visual highlight on selected tile and handle mouse navigation.
         /// </summary>
         [HarmonyPostfix]
         public static void Postfix()
@@ -263,6 +268,9 @@ namespace RimWorldAccess
 
             // For additional visual feedback, we could draw text overlay
             DrawTileInfoOverlay(selectedTile);
+
+            // Handle mouse navigation for automatic tile announcement on world map
+            HandleMouseNavigation();
         }
 
         /// <summary>
@@ -311,6 +319,82 @@ namespace RimWorldAccess
             // Reset text settings
             Text.Anchor = TextAnchor.UpperLeft;
             Text.Font = GameFont.Small;
+        }
+
+        /// <summary>
+        /// Handles mouse navigation for automatic tile announcement on world map.
+        /// </summary>
+        private static void HandleMouseNavigation()
+        {
+            // Skip if any accessibility menu is active
+            if (KeyboardHelper.IsAnyAccessibilityMenuActive())
+                return;
+
+            // Skip if caravan formation dialog is active (unless choosing destination)
+            if (CaravanFormationState.IsActive && !CaravanFormationState.IsChoosingDestination)
+                return;
+
+            // Skip if world navigation is not active or initialized
+            if (!WorldNavigationState.IsActive || !WorldNavigationState.IsInitialized)
+                return;
+
+            // Check if left Ctrl is held down
+            bool ctrlHeldForMouse = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+
+            if (ctrlHeldForMouse)
+            {
+                // Get current mouse tile on world map
+                int mouseTile = -1;
+                if (WorldRendererUtility.WorldRendered && Find.World != null)
+                {
+                    // Use screen position to get tile under mouse
+                    mouseTile = GenWorld.TileAt(UI.MousePositionOnUI, true);
+                }
+
+                // Check if mouse tile is valid
+                if (mouseTile < 0)
+                {
+                    // Mouse not over a valid tile, reset tracking
+                    if (lastWorldMouseTile != -1)
+                    {
+                        lastWorldMouseTile = -1;
+                    }
+                    return;
+                }
+
+                // Check if mouse moved to a new tile
+                bool mouseTileChanged = mouseTile != lastWorldMouseTile;
+
+                // Check time since last arrow key press (to avoid announcing when using keyboard)
+                float timeSinceArrowKey = Time.time - lastWorldArrowKeyPressTime;
+                bool keyboardIdle = timeSinceArrowKey > 0.5f; // 0.5 seconds threshold
+
+                if (mouseTileChanged && keyboardIdle)
+                {
+                    // Get tile information
+                    PlanetTile tile = new PlanetTile(mouseTile);
+                    string tileInfo = WorldInfoHelper.GetTileSummary(tile);
+
+                    // Announce tile info with interrupt to cut off previous speech
+                    TolkHelper.Speak(tileInfo, SpeechPriority.High);
+
+                    // Update mouse tracking
+                    lastWorldMouseTile = mouseTile;
+                }
+                else if (!mouseTileChanged && lastWorldMouseTile != -1)
+                {
+                    // Mouse is still on the same tile, no need to announce
+                    return;
+                }
+            }
+            else
+            {
+                // Ctrl is not held - reset tracking to ensure clean state
+                if (lastWorldMouseTile != -1)
+                {
+                    lastWorldMouseTile = -1;
+                }
+            }
         }
     }
 }

--- a/src/World/WorldNavigationPatch.cs
+++ b/src/World/WorldNavigationPatch.cs
@@ -146,6 +146,13 @@ namespace RimWorldAccess
                 return;
             }
 
+            if (key == KeyCode.M && shift && !ctrl && !alt)
+            {
+                MoveSelectionToLastMouseTile();
+                Event.current.Use();
+                return;
+            }
+
             // Note: Comma and Period keys for caravan cycling are handled in UnifiedKeyboardPatch
             // at a higher priority to prevent colonist selection from intercepting them
 
@@ -395,6 +402,40 @@ namespace RimWorldAccess
                     lastWorldMouseTile = -1;
                 }
             }
+        }
+
+        /// <summary>
+        /// Moves world navigation to the last valid tile discovered by mouse exploration.
+        /// </summary>
+        private static void MoveSelectionToLastMouseTile()
+        {
+            if (lastWorldMouseTile < 0)
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return;
+            }
+
+            PlanetTile tile = new PlanetTile(lastWorldMouseTile);
+            if (!tile.Valid)
+            {
+                TolkHelper.Speak("No valid mouse position", SpeechPriority.Normal);
+                return;
+            }
+
+            WorldNavigationState.CurrentSelectedTile = tile;
+
+            if (Find.WorldSelector != null)
+            {
+                Find.WorldSelector.ClearSelection();
+                Find.WorldSelector.SelectedTile = tile;
+            }
+
+            if (Find.WorldCameraDriver != null)
+            {
+                Find.WorldCameraDriver.JumpTo(tile);
+            }
+
+            WorldNavigationState.AnnounceTile();
         }
     }
 }

--- a/src/World/WorldNavigationPatch.cs
+++ b/src/World/WorldNavigationPatch.cs
@@ -338,10 +338,10 @@ namespace RimWorldAccess
             if (!WorldNavigationState.IsActive || !WorldNavigationState.IsInitialized)
                 return;
 
-            // Check if left Ctrl is held down
-            bool ctrlHeldForMouse = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+            // Check if left Shift is held down to avoid screen reader Ctrl interruption
+            bool shiftHeldForMouse = Input.GetKey(KeyCode.LeftShift);
 
-            if (ctrlHeldForMouse)
+            if (shiftHeldForMouse)
             {
                 // Get current mouse tile on world map
                 int mouseTile = -1;
@@ -389,7 +389,7 @@ namespace RimWorldAccess
             }
             else
             {
-                // Ctrl is not held - reset tracking to ensure clean state
+                // Shift is not held - reset tracking to ensure clean state
                 if (lastWorldMouseTile != -1)
                 {
                     lastWorldMouseTile = -1;


### PR DESCRIPTION
Adds mouse-driven map/world exploration while holding Left Shift, plus Shift+M cursor sync. Based on current upstream/master. Tested with: dotnet build -c Release --no-restore.