### PR TITLE
feat: add Quality Builder mod accessibility

### DIFF
--- a/src/Core/ModDetectionHelper.cs
+++ b/src/Core/ModDetectionHelper.cs
@@ -1,0 +1,362 @@
+using System;
+using System.Reflection;
+using Verse;
+using RimWorld;
+
+namespace RimWorldAccess
+{
+    /// <summary>
+    /// Provides safe detection and access to third-party mods.
+    /// All methods are designed to fail gracefully when mods are not installed.
+    /// </summary>
+    public static class ModDetectionHelper
+    {
+        // Cached reflection results for performance
+        private static bool? _isQualityBuilderActive = null;
+        private static Type _qualityBuilderType = null;
+        private static MethodInfo _hasDesignationMethod = null;
+        private static MethodInfo _setSkilledMethod = null;
+        private static MethodInfo _getDesignationOnThingMethod = null;
+
+        /// <summary>
+        /// Checks if the Quality Builder mod is active.
+        /// Uses ModsConfig.IsActive for reliable detection.
+        /// </summary>
+        public static bool IsQualityBuilderActive()
+        {
+            if (_isQualityBuilderActive.HasValue)
+                return _isQualityBuilderActive.Value;
+
+            // First try: ModsConfig check (most reliable)
+            _isQualityBuilderActive = ModsConfig.IsActive("QualityBuilder");
+
+            // Second try: Type existence check (fallback)
+            if (!_isQualityBuilderActive.Value)
+            {
+                _qualityBuilderType = Type.GetType("QualityBuilder.QualityBuilder, QualityBuilder");
+                _isQualityBuilderActive = _qualityBuilderType != null;
+            }
+
+            return _isQualityBuilderActive.Value;
+        }
+
+        /// <summary>
+        /// Gets the QualityBuilder type via reflection.
+        /// Returns null if mod is not active.
+        /// </summary>
+        public static Type GetQualityBuilderType()
+        {
+            if (!IsQualityBuilderActive())
+                return null;
+
+            if (_qualityBuilderType == null)
+            {
+                _qualityBuilderType = Type.GetType("QualityBuilder.QualityBuilder, QualityBuilder");
+            }
+
+            return _qualityBuilderType;
+        }
+
+        /// <summary>
+        /// Safely checks if a thing has a Quality Builder designation.
+        /// Returns false if mod is not active or on error.
+        /// </summary>
+        public static bool HasQualityBuilderDesignation(Thing thing)
+        {
+            try
+            {
+                if (!IsQualityBuilderActive() || thing == null)
+                    return false;
+
+                if (_hasDesignationMethod == null)
+                {
+                    var type = GetQualityBuilderType();
+                    if (type == null) return false;
+                    _hasDesignationMethod = type.GetMethod("hasDesignation", BindingFlags.Public | BindingFlags.Static);
+                }
+
+                if (_hasDesignationMethod == null)
+                    return false;
+
+                return (bool)_hasDesignationMethod.Invoke(null, new object[] { thing });
+            }
+            catch
+            {
+                // Graceful degradation: if anything fails, assume no designation
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Safely gets the current quality designation level for a thing.
+        /// Returns null if no designation or mod not active.
+        /// </summary>
+        public static string GetCurrentQualityLevel(Thing thing)
+        {
+            try
+            {
+                if (!IsQualityBuilderActive() || thing == null)
+                    return null;
+
+                if (_getDesignationOnThingMethod == null)
+                {
+                    var type = GetQualityBuilderType();
+                    if (type == null) return null;
+                    _getDesignationOnThingMethod = type.GetMethod("getDesignationOnThing", BindingFlags.Public | BindingFlags.Static);
+                }
+
+                if (_getDesignationOnThingMethod == null)
+                    return null;
+
+                var designation = _getDesignationOnThingMethod.Invoke(null, new object[] { thing });
+                if (designation == null)
+                    return null;
+
+                // Extract quality level from designation def name
+                var defProperty = designation.GetType().GetProperty("def");
+                if (defProperty == null) return null;
+
+                var def = defProperty.GetValue(designation);
+                if (def == null) return null;
+
+                var defNameProperty = def.GetType().GetProperty("defName");
+                if (defNameProperty == null) return null;
+
+                string defName = defNameProperty.GetValue(def) as string;
+                if (string.IsNullOrEmpty(defName))
+                    return null;
+
+                // Parse quality from "SkilledBuilderX" where X is optional number
+                if (defName.StartsWith("SkilledBuilder"))
+                {
+                    if (defName == "SkilledBuilder") return "Normal"; // Default
+
+                    string numberPart = defName.Substring("SkilledBuilder".Length);
+                    if (int.TryParse(numberPart, out int level))
+                    {
+                        switch (level)
+                        {
+                            case 2: return "Poor";
+                            case 3: return "Normal";
+                            case 4: return "Good";
+                            case 5: return "Excellent";
+                            case 6: return "Masterwork";
+                            case 7: return "Legendary";
+                            default: return "Unknown";
+                        }
+                    }
+                }
+
+                return null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Safely gets the quality category enum value for a thing.
+        /// Returns null if no designation or mod not active.
+        /// </summary>
+        public static int? GetCurrentQualityCategory(Thing thing)
+        {
+            try
+            {
+                if (!IsQualityBuilderActive() || thing == null)
+                    return null;
+
+                var level = GetCurrentQualityLevel(thing);
+                if (level == null) return null;
+
+                switch (level)
+                {
+                    case "Poor": return 2;
+                    case "Normal": return 3;
+                    case "Good": return 4;
+                    case "Excellent": return 5;
+                    case "Masterwork": return 6;
+                    case "Legendary": return 7;
+                    default: return null;
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Safely sets or removes a quality designation on a thing.
+        /// </summary>
+        /// <param name="thing">Target thing (blueprint/frame)</param>
+        /// <param name="qualityCategory">QualityCategory enum value (2-7), or null to remove</param>
+        /// <returns>True if successful, false otherwise</returns>
+        public static bool SetQualityDesignation(Thing thing, int? qualityCategory)
+        {
+            try
+            {
+                if (!IsQualityBuilderActive() || thing == null)
+                    return false;
+
+                if (_setSkilledMethod == null)
+                {
+                    var type = GetQualityBuilderType();
+                    if (type == null) return false;
+                    _setSkilledMethod = type.GetMethod("setSkilled", BindingFlags.Public | BindingFlags.Static);
+                }
+
+                if (_setSkilledMethod == null)
+                    return false;
+
+                // Convert int? to QualityCategory? enum for the mod's method
+                if (qualityCategory.HasValue)
+                {
+                    // The mod expects QualityCategory enum from RimWorld
+                    // QualityCategory is in RimWorld namespace, not Verse
+                    object enumValue = null;
+                    try
+                    {
+                        // Try to create the enum value directly
+                        enumValue = Enum.ToObject(typeof(QualityCategory), qualityCategory.Value);
+                    }
+                    catch
+                    {
+                        // Fallback: use reflection
+                        var rimworldAssembly = typeof(QualityCategory).Assembly;
+                        var qualityCategoryType = rimworldAssembly.GetType("RimWorld.QualityCategory");
+                        if (qualityCategoryType == null) return false;
+                        enumValue = Enum.ToObject(qualityCategoryType, qualityCategory.Value);
+                    }
+
+                    if (enumValue == null) return false;
+
+                    _setSkilledMethod.Invoke(null, new object[] { thing, enumValue, true });
+                }
+                else
+                {
+                    // Remove designation (pass null for category and false for add)
+                    _setSkilledMethod.Invoke(null, new object[] { thing, null, false });
+                }
+
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Gets the localized label for a quality level.
+        /// Uses game's localization for quality categories when available.
+        /// Falls back to English labels.
+        /// </summary>
+        public static string GetQualityLabel(int qualityCategory)
+        {
+            // Try to use game's localization for quality categories
+            try
+            {
+                string key = "QualityCategory_" + qualityCategory;
+                string translated = key.Translate();
+                if (translated != key) // Translation exists
+                    return translated;
+            }
+            catch
+            {
+                // Fall through to English defaults
+            }
+
+            // English fallback (as per user requirement for untranslated terms)
+            switch (qualityCategory)
+            {
+                case 2: return "Poor";
+                case 3: return "Normal";
+                case 4: return "Good";
+                case 5: return "Excellent";
+                case 6: return "Masterwork";
+                case 7: return "Legendary";
+                default: return "Unknown";
+            }
+        }
+
+        /// <summary>
+        /// Gets the full announcement for a quality designation.
+        /// Includes both the label and description.
+        /// </summary>
+        public static string GetQualityAnnouncement(int qualityCategory)
+        {
+            string label = GetQualityLabel(qualityCategory);
+            string description = GetQualityDescription(qualityCategory);
+            return $"{label}. {description}";
+        }
+
+        /// <summary>
+        /// Gets the description for a quality level.
+        /// Uses English descriptions as per user requirement.
+        /// </summary>
+        public static string GetQualityDescription(int qualityCategory)
+        {
+            switch (qualityCategory)
+            {
+                case 2: return "Poor quality - basic functionality";
+                case 3: return "Normal quality - standard construction";
+                case 4: return "Good quality - above average work";
+                case 5: return "Excellent quality - skilled craftsmanship";
+                case 6: return "Masterwork quality - exceptional artistry";
+                case 7: return "Legendary quality - unparalleled masterpiece";
+                default: return "Unknown quality level";
+            }
+        }
+
+        /// <summary>
+        /// Checks if a thing can have quality designations (is a blueprint or frame).
+        /// </summary>
+        public static bool CanHaveQualityDesignation(Thing thing)
+        {
+            if (thing == null) return false;
+
+            // Quality Builder works on blueprints and frames
+            if (thing.def.IsBlueprint || thing.def.IsFrame)
+                return true;
+
+            // Check for blueprint types
+            Type thingType = thing.GetType();
+
+            // Check for direct blueprint types
+            if (typeof(Blueprint).IsAssignableFrom(thingType))
+                return true;
+
+            // Check for specific blueprint classes
+            if (thingType.Name.Contains("Blueprint"))
+                return true;
+
+            // Check for Blueprint_Build, Blueprint_Install, etc.
+            if (thingType.FullName?.Contains("Blueprint") == true)
+                return true;
+
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the announcement for current quality on a thing.
+        /// Returns empty string if no quality designation or mod not active.
+        /// </summary>
+        public static string GetCurrentQualityAnnouncement(Thing thing)
+        {
+            if (!IsQualityBuilderActive() || !CanHaveQualityDesignation(thing))
+                return string.Empty;
+
+            var currentLevel = GetCurrentQualityLevel(thing);
+            if (string.IsNullOrEmpty(currentLevel))
+                return string.Empty;
+
+            int? category = GetCurrentQualityCategory(thing);
+            if (!category.HasValue)
+                return string.Empty;
+
+            string label = GetQualityLabel(category.Value);
+            return $"Required quality: {label}";
+        }
+    }
+}

--- a/src/Input/KeyboardHelper.cs
+++ b/src/Input/KeyboardHelper.cs
@@ -324,6 +324,8 @@ namespace RimWorldAccess
                 || HistoryState.IsActive
                 || HistoryStatisticsState.IsActive
                 || HistoryMessagesState.IsActive
+                // Quality Builder menu
+                || QualityBuilderMenuState.IsActive
                 // Building placement modes
                 || ViewingModeState.IsActive
                 || ShapePlacementState.IsActive

--- a/src/Input/UnifiedKeyboardPatch.cs
+++ b/src/Input/UnifiedKeyboardPatch.cs
@@ -4205,6 +4205,105 @@ namespace RimWorldAccess
                 }
             }
 
+            // ===== PRIORITY 4.76: Handle Quality Builder menu with Q key =====
+            if (key == KeyCode.Q && !Event.current.shift && !Event.current.control && !Event.current.alt)
+            {
+                // Conditions: gameplay, map exists, no windows preventing camera motion, no accessibility menu active, Quality Builder mod active.
+                if (Current.ProgramState == ProgramState.Playing &&
+                    Find.CurrentMap != null &&
+                    (Find.WindowStack == null || !Find.WindowStack.WindowsPreventCameraMotion) &&
+                    !KeyboardHelper.IsAnyAccessibilityMenuActive() &&
+                    ModDetectionHelper.IsQualityBuilderActive())
+                {
+                    // Get cursor position
+                    IntVec3 cursorPos = MapNavigationState.CurrentCursorPosition;
+                    if (cursorPos.IsValid && cursorPos.InBounds(Find.CurrentMap))
+                    {
+                        // Look for a building at the cursor position (blueprint or frame)
+                        Thing thing = null;
+                        var thingsAtCursor = Find.CurrentMap.thingGrid.ThingsAt(cursorPos);
+                        int totalThings = 0;
+                        int blueprintCount = 0;
+                        foreach (var t in thingsAtCursor)
+                        {
+                            totalThings++;
+                            // First check if it already has a quality designation
+                            if (ModDetectionHelper.HasQualityBuilderDesignation(t))
+                            {
+                                thing = t;
+                                blueprintCount++;
+                                break; // Prefer things with existing designations
+                            }
+                            // Then check if it can have a quality designation
+                            else if (ModDetectionHelper.CanHaveQualityDesignation(t))
+                            {
+                                thing = t;
+                                blueprintCount++;
+                                // Don't break, continue to count all blueprints
+                                // but we'll use the first one found without a designation
+                            }
+                        }
+
+                        if (thing != null)
+                        {
+                            // If multiple blueprints, announce count
+                            if (blueprintCount > 1)
+                            {
+                                TolkHelper.Speak($"Found {blueprintCount} blueprints/frames", SpeechPriority.Low);
+                            }
+
+                            // Open the quality menu for this thing
+                            bool opened = QualityBuilderMenuState.Open(thing);
+                            if (opened)
+                            {
+                                Event.current.Use();
+                                return;
+                            }
+                            else
+                            {
+                                // Menu failed to open
+                                TolkHelper.Speak("Cannot open quality menu", SpeechPriority.Normal);
+                                Event.current.Use();
+                                return;
+                            }
+                        }
+                        else
+                        {
+                            // No blueprint found
+                            if (totalThings == 0)
+                            {
+                                TolkHelper.Speak("No objects at cursor position", SpeechPriority.Normal);
+                            }
+                            else
+                            {
+                                TolkHelper.Speak($"Found {totalThings} objects but no blueprints or frames", SpeechPriority.Normal);
+                            }
+                            Event.current.Use();
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        // Invalid cursor position
+                        TolkHelper.Speak("Invalid cursor position", SpeechPriority.Normal);
+                        Event.current.Use();
+                        return;
+                    }
+                }
+            }
+
+            // ===== PRIORITY 4.771: Handle Quality Builder menu if active =====
+            if (QualityBuilderMenuState.IsActive)
+            {
+                Log.Message($"[UnifiedKeyboardPatch] QualityBuilderMenuState.IsActive=true, key={key}");
+                if (QualityBuilderMenuState.HandleInput())
+                {
+                    Event.current.Use();
+                    return;
+                }
+                Log.Message($"[UnifiedKeyboardPatch] QualityBuilderMenuState.HandleInput() returned false for key={key}");
+            }
+
             // ===== PRIORITY 4.77: Handle notification menu if active =====
             if (NotificationMenuState.IsActive)
             {

--- a/src/Map/MapNavigationPatch.cs
+++ b/src/Map/MapNavigationPatch.cs
@@ -93,7 +93,8 @@ namespace RimWorldAccess
                 // History tab states
                 HistoryState.IsActive ||
                 HistoryStatisticsState.IsActive ||
-                HistoryMessagesState.IsActive;
+                HistoryMessagesState.IsActive ||
+                QualityBuilderMenuState.IsActive;
                 // Note: TransportPodSelectionState, GizmoZoneEditState, and ShelfLinkingState are
                 // NOT included - they use the map cursor (arrow keys) for cell selection.
         }

--- a/src/QualityBuilder/QualityBuilderInspectionHelper.cs
+++ b/src/QualityBuilder/QualityBuilderInspectionHelper.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using Verse;
+using RimWorld;
+
+namespace RimWorldAccess
+{
+    /// <summary>
+    /// Provides inspection support for Quality Builder mod.
+    /// Adds Quality Builder category to inspection tree when mod is active.
+    /// </summary>
+    public static class QualityBuilderInspectionHelper
+    {
+        /// <summary>
+        /// Gets the Quality Builder category info for a thing if applicable.
+        /// Returns null if mod not active or thing cannot have quality designations.
+        /// </summary>
+        public static TabCategoryInfo GetQualityBuilderCategory(Thing thing)
+        {
+            if (!ModDetectionHelper.IsQualityBuilderActive() ||
+                !ModDetectionHelper.CanHaveQualityDesignation(thing))
+            {
+                return null;
+            }
+
+            return new TabCategoryInfo
+            {
+                Name = "Quality Builder",
+                Tab = null, // Synthetic category, not a real RimWorld tab
+                Handler = TabHandlerType.Action,
+                IsKnown = true,
+                OriginalCategoryName = "Quality Builder"
+            };
+        }
+
+        /// <summary>
+        /// Opens the Quality Builder menu for a thing.
+        /// Called when user selects the Quality Builder category in inspection tree.
+        /// </summary>
+        public static void OpenQualityBuilderMenu(Thing thing)
+        {
+            if (!ModDetectionHelper.IsQualityBuilderActive() || thing == null)
+                return;
+
+            bool opened = QualityBuilderMenuState.Open(thing);
+            if (!opened)
+            {
+                TolkHelper.Speak("Cannot open quality settings for this object", SpeechPriority.Normal);
+            }
+        }
+
+        /// <summary>
+        /// Gets the inspection string for Quality Builder info.
+        /// Used when displaying quality information in the inspection tree.
+        /// </summary>
+        public static string GetQualityBuilderInfoString(Thing thing)
+        {
+            if (!ModDetectionHelper.IsQualityBuilderActive() || thing == null)
+                return string.Empty;
+
+            var currentLevel = ModDetectionHelper.GetCurrentQualityLevel(thing);
+            if (string.IsNullOrEmpty(currentLevel))
+                return "No quality requirement set";
+
+            int? category = ModDetectionHelper.GetCurrentQualityCategory(thing);
+            if (!category.HasValue)
+                return "Unknown quality level";
+
+            string label = ModDetectionHelper.GetQualityLabel(category.Value);
+            return $"Required quality: {label}";
+        }
+
+        /// <summary>
+        /// Builds the tree item for Quality Builder category.
+        /// Used by InspectionTreeBuilder to create the navigation tree.
+        /// </summary>
+        public static InspectionTreeItem BuildQualityBuilderTreeItem(Thing thing)
+        {
+            var item = new InspectionTreeItem
+            {
+                Type = InspectionTreeItem.ItemType.Action,
+                Label = "Quality Builder",
+                Description = GetQualityBuilderInfoString(thing),
+                IsExpandable = false,
+                OnActivate = () => OpenQualityBuilderMenu(thing)
+            };
+
+            return item;
+        }
+
+        /// <summary>
+        /// Checks if a thing currently has a Quality Builder designation.
+        /// Used for quick status display.
+        /// </summary>
+        public static bool HasActiveQualityDesignation(Thing thing)
+        {
+            return ModDetectionHelper.HasQualityBuilderDesignation(thing);
+        }
+
+        /// <summary>
+        /// Gets the quick status announcement for quality.
+        /// Used when announcing tile info or quick inspections.
+        /// </summary>
+        public static string GetQualityStatusAnnouncement(Thing thing)
+        {
+            if (!ModDetectionHelper.IsQualityBuilderActive() || thing == null)
+                return string.Empty;
+
+            var currentLevel = ModDetectionHelper.GetCurrentQualityLevel(thing);
+            if (string.IsNullOrEmpty(currentLevel))
+                return string.Empty;
+
+            int? category = ModDetectionHelper.GetCurrentQualityCategory(thing);
+            if (!category.HasValue)
+                return string.Empty;
+
+            string label = ModDetectionHelper.GetQualityLabel(category.Value);
+            return $", Quality requirement: {label}";
+        }
+
+        /// <summary>
+        /// Toggles quality requirement on/off for a thing.
+        /// If no quality is set, defaults to Normal. If quality is set, removes it.
+        /// </summary>
+        public static void ToggleQualityRequirement(Thing thing)
+        {
+            if (!ModDetectionHelper.IsQualityBuilderActive() || thing == null)
+                return;
+
+            bool hasDesignation = ModDetectionHelper.HasQualityBuilderDesignation(thing);
+
+            if (hasDesignation)
+            {
+                // Remove quality requirement
+                bool success = ModDetectionHelper.SetQualityDesignation(thing, null);
+                if (success)
+                {
+                    TolkHelper.Speak("Quality requirement removed", SpeechPriority.Normal);
+                }
+                else
+                {
+                    TolkHelper.Speak("Failed to remove quality requirement", SpeechPriority.High);
+                }
+            }
+            else
+            {
+                // Add default quality requirement (Normal)
+                bool success = ModDetectionHelper.SetQualityDesignation(thing, 3); // Normal quality
+                if (success)
+                {
+                    TolkHelper.Speak("Normal quality requirement set", SpeechPriority.Normal);
+                }
+                else
+                {
+                    TolkHelper.Speak("Failed to set quality requirement", SpeechPriority.High);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets all quality levels as tree items for selection.
+        /// Used when building the quality selection menu tree.
+        /// </summary>
+        public static List<InspectionTreeItem> GetQualityLevelTreeItems(Thing thing)
+        {
+            var items = new List<InspectionTreeItem>();
+
+            if (!ModDetectionHelper.IsQualityBuilderActive() || thing == null)
+                return items;
+
+            // Add "Remove quality" option
+            items.Add(new InspectionTreeItem
+            {
+                Type = InspectionTreeItem.ItemType.Action,
+                Label = "Remove quality requirement",
+                Description = "Remove any quality requirement from this blueprint/frame",
+                OnActivate = () =>
+                {
+                    ModDetectionHelper.SetQualityDesignation(thing, null);
+                    TolkHelper.Speak("Quality requirement removed", SpeechPriority.Normal);
+                }
+            });
+
+            // Add quality level options
+            for (int quality = 2; quality <= 7; quality++) // Poor (2) to Legendary (7)
+            {
+                int qualityLevel = quality; // Capture for lambda
+                string label = ModDetectionHelper.GetQualityLabel(qualityLevel);
+                string description = ModDetectionHelper.GetQualityDescription(qualityLevel);
+
+                items.Add(new InspectionTreeItem
+                {
+                    Type = InspectionTreeItem.ItemType.Action,
+                    Label = label,
+                    Description = description,
+                    OnActivate = () =>
+                    {
+                        bool success = ModDetectionHelper.SetQualityDesignation(thing, qualityLevel);
+                        if (success)
+                        {
+                            TolkHelper.Speak($"Quality set to {label}", SpeechPriority.Normal);
+                        }
+                        else
+                        {
+                            TolkHelper.Speak($"Failed to set quality to {label}", SpeechPriority.High);
+                        }
+                    }
+                });
+            }
+
+            return items;
+        }
+    }
+}

--- a/src/QualityBuilder/QualityBuilderMenuState.cs
+++ b/src/QualityBuilder/QualityBuilderMenuState.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Verse;
+using RimWorld;
+
+namespace RimWorldAccess
+{
+    /// <summary>
+    /// Manages keyboard navigation for Quality Builder quality selection menu.
+    /// Provides an accessible alternative to the native FloatMenu.
+    /// </summary>
+    public static class QualityBuilderMenuState
+    {
+        private static bool isActive = false;
+        private static Thing targetThing = null;
+        private static int selectedIndex = 0;
+        private static List<int> qualityLevels = new List<int> { 2, 3, 4, 5, 6, 7 }; // Poor, Normal, Good, Excellent, Masterwork, Legendary
+
+        // Store the original quality before changes for undo/escape
+        private static int? originalQuality = null;
+
+        public static bool IsActive => isActive;
+        public static Thing TargetThing => targetThing;
+
+        /// <summary>
+        /// Opens the quality selection menu for a specific thing (blueprint/frame).
+        /// Returns false if mod is not active or thing cannot have quality designations.
+        /// </summary>
+        public static bool Open(Thing thing)
+        {
+            if (!ModDetectionHelper.IsQualityBuilderActive() ||
+                !ModDetectionHelper.CanHaveQualityDesignation(thing))
+            {
+                Log.Message($"[QualityBuilderMenuState] Open failed: mod active={ModDetectionHelper.IsQualityBuilderActive()}, can have designation={ModDetectionHelper.CanHaveQualityDesignation(thing)}");
+                return false;
+            }
+
+            targetThing = thing;
+            isActive = true;
+            Log.Message($"[QualityBuilderMenuState] Menu opened for thing {thing}, isActive={isActive}");
+
+            // Get current quality to restore on Escape
+            originalQuality = ModDetectionHelper.GetCurrentQualityCategory(thing);
+            Log.Message($"[QualityBuilderMenuState] Original quality: {originalQuality}");
+
+            // Set selection to current quality if exists, otherwise to Normal (index 1)
+            if (originalQuality.HasValue)
+            {
+                int index = qualityLevels.IndexOf(originalQuality.Value);
+                selectedIndex = index >= 0 ? index : 1; // Default to Normal
+            }
+            else
+            {
+                selectedIndex = 1; // Normal quality
+            }
+            Log.Message($"[QualityBuilderMenuState] Selected index: {selectedIndex}");
+
+            AnnounceCurrentSelection();
+            return true;
+        }
+
+        /// <summary>
+        /// Opens the quality selection menu for the thing at the current cursor position.
+        /// </summary>
+        public static bool OpenForCursor()
+        {
+            if (!ModDetectionHelper.IsQualityBuilderActive())
+                return false;
+
+            var map = Find.CurrentMap;
+            if (map == null)
+                return false;
+
+            var cursorPos = MapNavigationState.CurrentCursorPosition;
+            var thing = map.thingGrid.ThingAt(cursorPos, ThingCategory.Building);
+
+            if (thing == null || !ModDetectionHelper.CanHaveQualityDesignation(thing))
+            {
+                TolkHelper.Speak("No blueprint or frame at cursor position", SpeechPriority.Normal);
+                return false;
+            }
+
+            return Open(thing);
+        }
+
+        /// <summary>
+        /// Closes the quality selection menu.
+        /// </summary>
+        public static void Close()
+        {
+            Log.Message($"[QualityBuilderMenuState] Close called, was active={isActive}");
+            isActive = false;
+            targetThing = null;
+            selectedIndex = 0;
+            originalQuality = null;
+        }
+
+        /// <summary>
+        /// Moves selection to the next quality level.
+        /// </summary>
+        public static void SelectNext()
+        {
+            if (!isActive) return;
+
+            selectedIndex = MenuHelper.SelectNext(selectedIndex, qualityLevels.Count);
+            AnnounceCurrentSelection();
+        }
+
+        /// <summary>
+        /// Moves selection to the previous quality level.
+        /// </summary>
+        public static void SelectPrevious()
+        {
+            if (!isActive) return;
+
+            selectedIndex = MenuHelper.SelectPrevious(selectedIndex, qualityLevels.Count);
+            AnnounceCurrentSelection();
+        }
+
+        /// <summary>
+        /// Selects a specific quality level by index (0-5).
+        /// </summary>
+        public static void SelectIndex(int index)
+        {
+            if (!isActive) return;
+
+            if (index >= 0 && index < qualityLevels.Count)
+            {
+                selectedIndex = index;
+                AnnounceCurrentSelection();
+            }
+        }
+
+        /// <summary>
+        /// Selects a quality level by numeric key (1-7).
+        /// 1 = Remove designation, 2-7 = Poor-Legendary
+        /// </summary>
+        public static void SelectByNumberKey(int number)
+        {
+            if (!isActive) return;
+
+            if (number == 1)
+            {
+                // Remove quality designation
+                RemoveQuality();
+                return;
+            }
+
+            // Map 2-7 to indices 0-5
+            int index = number - 2;
+            if (index >= 0 && index < qualityLevels.Count)
+            {
+                SelectIndex(index);
+                ExecuteSelected();
+            }
+        }
+
+        /// <summary>
+        /// Executes the currently selected quality level.
+        /// Applies the quality designation to the target thing.
+        /// </summary>
+        public static void ExecuteSelected()
+        {
+            if (!isActive || targetThing == null) return;
+
+            int qualityCategory = qualityLevels[selectedIndex];
+            bool success = ModDetectionHelper.SetQualityDesignation(targetThing, qualityCategory);
+
+            if (success)
+            {
+                string announcement = ModDetectionHelper.GetQualityAnnouncement(qualityCategory);
+                TolkHelper.Speak($"Quality set: {announcement}", SpeechPriority.Normal);
+
+                // Keep menu open for further adjustments
+                originalQuality = qualityCategory;
+            }
+            else
+            {
+                TolkHelper.Speak("Failed to set quality designation", SpeechPriority.High);
+            }
+        }
+
+        /// <summary>
+        /// Removes the quality designation from the target thing.
+        /// </summary>
+        public static void RemoveQuality()
+        {
+            if (!isActive || targetThing == null) return;
+
+            bool success = ModDetectionHelper.SetQualityDesignation(targetThing, null);
+
+            if (success)
+            {
+                TolkHelper.Speak("Quality requirement removed", SpeechPriority.Normal);
+                originalQuality = null;
+
+                // Keep menu open for new selection
+                selectedIndex = 1; // Reset to Normal
+            }
+            else
+            {
+                TolkHelper.Speak("Failed to remove quality designation", SpeechPriority.High);
+            }
+        }
+
+        /// <summary>
+        /// Cancels changes and closes the menu.
+        /// Restores original quality if it was changed during this session.
+        /// </summary>
+        public static void Cancel()
+        {
+            if (!isActive) return;
+
+            // Check if quality was changed during this session
+            int? currentQuality = ModDetectionHelper.GetCurrentQualityCategory(targetThing);
+            if (originalQuality != currentQuality)
+            {
+                // Restore original quality
+                ModDetectionHelper.SetQualityDesignation(targetThing, originalQuality);
+
+                if (originalQuality.HasValue)
+                {
+                    string label = ModDetectionHelper.GetQualityLabel(originalQuality.Value);
+                    TolkHelper.Speak($"Changes cancelled. Quality restored to {label}", SpeechPriority.Normal);
+                }
+                else
+                {
+                    TolkHelper.Speak("Changes cancelled. Quality requirement removed", SpeechPriority.Normal);
+                }
+            }
+            else
+            {
+                TolkHelper.Speak("Quality selection cancelled", SpeechPriority.Normal);
+            }
+
+            Close();
+        }
+
+        /// <summary>
+        /// Gets the current selected quality level.
+        /// </summary>
+        public static int GetSelectedQuality()
+        {
+            if (!isActive || selectedIndex < 0 || selectedIndex >= qualityLevels.Count)
+                return 3; // Default to Normal
+
+            return qualityLevels[selectedIndex];
+        }
+
+        /// <summary>
+        /// Gets the announcement for the current selection.
+        /// </summary>
+        private static void AnnounceCurrentSelection()
+        {
+            if (!isActive) return;
+
+            int quality = qualityLevels[selectedIndex];
+            string label = ModDetectionHelper.GetQualityLabel(quality);
+            string description = ModDetectionHelper.GetQualityDescription(quality);
+            string position = MenuHelper.FormatPosition(selectedIndex, qualityLevels.Count);
+
+            string announcement = $"{label}. {description}";
+            if (!string.IsNullOrEmpty(position))
+                announcement += $" {position}";
+
+            announcement += " Press Enter to confirm, Escape to cancel, 1 to remove quality.";
+
+            TolkHelper.Speak(announcement, SpeechPriority.Low);
+        }
+
+        /// <summary>
+        /// Handles keyboard input for the quality selection menu.
+        /// Returns true if input was handled.
+        /// </summary>
+        public static bool HandleInput()
+        {
+            Log.Message($"[QualityBuilderMenuState] HandleInput entry, isActive={isActive}, key={Event.current.keyCode}");
+
+            if (!isActive)
+            {
+                Log.Message($"[QualityBuilderMenuState] HandleInput: menu not active, returning false");
+                return false;
+            }
+            if (Event.current.type != EventType.KeyDown)
+            {
+                Log.Message($"[QualityBuilderMenuState] HandleInput: not KeyDown event, returning false");
+                return false;
+            }
+
+            var key = Event.current.keyCode;
+            Log.Message($"[QualityBuilderMenuState] HandleInput processing key={key}");
+
+            bool handled = false;
+
+            // Handle Escape - cancel
+            if (key == KeyCode.Escape)
+            {
+                Log.Message($"[QualityBuilderMenuState] HandleInput: Escape pressed, calling Cancel");
+                Cancel();
+                handled = true;
+            }
+            // Handle Enter/Return - execute selection
+            else if (key == KeyCode.Return || key == KeyCode.KeypadEnter)
+            {
+                Log.Message($"[QualityBuilderMenuState] HandleInput: Enter pressed, calling ExecuteSelected");
+                ExecuteSelected();
+                handled = true;
+            }
+            // Handle Up/Down arrows - navigation
+            else if (key == KeyCode.UpArrow)
+            {
+                Log.Message($"[QualityBuilderMenuState] HandleInput: UpArrow pressed, calling SelectPrevious");
+                SelectPrevious();
+                handled = true;
+            }
+            else if (key == KeyCode.DownArrow)
+            {
+                Log.Message($"[QualityBuilderMenuState] HandleInput: DownArrow pressed, calling SelectNext");
+                SelectNext();
+                handled = true;
+            }
+            // Handle number keys 1-7 for quick selection
+            else if (key >= KeyCode.Alpha1 && key <= KeyCode.Alpha7)
+            {
+                int number = (int)(key - KeyCode.Alpha1) + 1;
+                Log.Message($"[QualityBuilderMenuState] HandleInput: Number key {number} pressed, calling SelectByNumberKey");
+                SelectByNumberKey(number);
+                handled = true;
+            }
+            // Handle keypad numbers 1-7
+            else if (key >= KeyCode.Keypad1 && key <= KeyCode.Keypad7)
+            {
+                int number = (int)(key - KeyCode.Keypad1) + 1;
+                Log.Message($"[QualityBuilderMenuState] HandleInput: Keypad number {number} pressed, calling SelectByNumberKey");
+                SelectByNumberKey(number);
+                handled = true;
+            }
+            // Handle Home - jump to first (Poor)
+            else if (key == KeyCode.Home)
+            {
+                Log.Message($"[QualityBuilderMenuState] HandleInput: Home pressed, jumping to first");
+                SelectIndex(0);
+                handled = true;
+            }
+            // Handle End - jump to last (Legendary)
+            else if (key == KeyCode.End)
+            {
+                Log.Message($"[QualityBuilderMenuState] HandleInput: End pressed, jumping to last");
+                SelectIndex(qualityLevels.Count - 1);
+                handled = true;
+            }
+            else
+            {
+                Log.Message($"[QualityBuilderMenuState] HandleInput: Key {key} not specifically handled");
+            }
+
+            // If menu is active, consume ALL key events to prevent them from leaking to the game
+            if (isActive)
+            {
+                Log.Message($"[QualityBuilderMenuState] HandleInput: Menu active, consuming event and returning true");
+                Event.current.Use();
+                // Return true even for unhandled keys to block them
+                return true;
+            }
+
+            Log.Message($"[QualityBuilderMenuState] HandleInput: Menu not active, returning handled={handled}");
+            return handled;
+        }
+    }
+}


### PR DESCRIPTION
Adds optional Quality Builder mod detection and accessible quality designation controls without requiring the mod at runtime. Based on current upstream/master. Tested with: dotnet build -c Release --no-restore.