### PR TITLE
fix: announce implied inverse relations (parent sees child, etc.)

### DIFF
--- a/src/Pawns/SocialTabHelper.cs
+++ b/src/Pawns/SocialTabHelper.cs
@@ -279,17 +279,11 @@ namespace RimWorldAccess
         {
             var labels = new List<string>();
 
-            var directRelations = pawn.relations.DirectRelations;
-            if (directRelations != null)
+            // Use PawnRelationUtility.GetRelations to catch implied/derived relations
+            // (e.g. Parent stores Child as an implied inverse, not in DirectRelations)
+            foreach (var def in pawn.GetRelations(otherPawn))
             {
-                foreach (var rel in directRelations)
-                {
-                    if (rel.otherPawn == otherPawn)
-                    {
-                        // Use GetGenderSpecificLabelCap to get the correct label based on the other pawn's gender
-                        labels.Add(rel.def.GetGenderSpecificLabelCap(otherPawn));
-                    }
-                }
+                labels.Add(def.GetGenderSpecificLabelCap(otherPawn));
             }
 
             // Add friendship/rivalry labels if no family relations
@@ -353,17 +347,13 @@ namespace RimWorldAccess
             sb.AppendLine("Opinion factors:");
             bool hasFactors = false;
 
-            // Add relation opinion modifiers
-            var directRelations = pawn.relations.DirectRelations;
-            if (directRelations != null)
+            // Add relation opinion modifiers — mirrors vanilla Pawn_RelationsTracker.OpinionExplanation
+            foreach (var def in pawn.GetRelations(otherPawn))
             {
-                foreach (var rel in directRelations)
+                if (def.opinionOffset != 0)
                 {
-                    if (rel.otherPawn == otherPawn && rel.def.opinionOffset != 0)
-                    {
-                        sb.AppendLine($"  {rel.def.GetGenderSpecificLabelCap(otherPawn)}: {rel.def.opinionOffset:+0;-0;0}");
-                        hasFactors = true;
-                    }
+                    sb.AppendLine($"  {def.GetGenderSpecificLabelCap(otherPawn)}: {def.opinionOffset:+0;-0;0}");
+                    hasFactors = true;
                 }
             }
 


### PR DESCRIPTION
## Summary

`SocialTabHelper.GetRelationLabels` iterated `pawn.relations.DirectRelations`, which only holds one side of asymmetric relations. The child stores `Parent` as a `DirectRelation`; the parent has no `Child` entry because `Child` is the implied inverse on the def (`PawnRelationDef.implied`). From the parent's perspective, the daughter was therefore unlabeled and fell through to the opinion-based fallback — typically announced as "Friend" at opinion ≥ 20 instead of "Daughter"/"Son".

Same bug shape in `GetRelationDetailedInfo`'s opinion-factor loop: the breakdown didn't list "Daughter: +X" on the parent's side, so the line items didn't add up to the opinion number shown above them.

## Fix

Both spots now use the `PawnRelationUtility.GetRelations(other)` extension, which walks every `PawnRelationDef` and runs `def.Worker.InRelation(me, other)` — the same source `Pawn_RelationsTracker.OpinionOf` and `OpinionExplanation` use internally. Implied inverses are discovered correctly, so labels and the opinion breakdown are now symmetric.

## Test plan

- [x] Build cleanly (`dotnet build`)
- [x] Verified in-game: mother's Relations tree shows the daughter as "Daughter" (was "Friend"); daughter's tree still shows the mother as "Mother"
- [x] Opinion-factor breakdown now lists the relation modifier on both sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)