### PR TITLE
fix: stop trait picker crash and fix gender agreement in resolved descriptions

### DIFF
--- a/Languages/ChineseSimplified/Keyed/RimWorldAccess_MainMenu.xml
+++ b/Languages/ChineseSimplified/Keyed/RimWorldAccess_MainMenu.xml
@@ -758,4 +758,6 @@
   <RimWorldAccess.StartingPawn.EditPawnFilter>编辑角色筛选器...</RimWorldAccess.StartingPawn.EditPawnFilter>
   <RimWorldAccess.StartingPawn.AddPawn>添加角色</RimWorldAccess.StartingPawn.AddPawn>
   <RimWorldAccess.StartingPawn.RemovePawn>移除角色</RimWorldAccess.StartingPawn.RemovePawn>
+  <RimWorldAccess.PawnFilter.TraitEffects>效果：{0}。</RimWorldAccess.PawnFilter.TraitEffects>
+  <RimWorldAccess.PawnFilter.TraitCannotDo>无法执行：{0}</RimWorldAccess.PawnFilter.TraitCannotDo>
 </LanguageData>

--- a/Languages/English/Keyed/RimWorldAccess_MainMenu.xml
+++ b/Languages/English/Keyed/RimWorldAccess_MainMenu.xml
@@ -569,6 +569,9 @@
   <RimWorldAccess.PawnFilter.SectionConditions>Conditions</RimWorldAccess.PawnFilter.SectionConditions>
   <RimWorldAccess.PawnFilter.SectionActions>Actions</RimWorldAccess.PawnFilter.SectionActions>
   <RimWorldAccess.PawnFilter.TraitEntryFormat>{0}: {1} {2}</RimWorldAccess.PawnFilter.TraitEntryFormat>
+  <!-- Gameplay-effect summary appended to a trait degree's description in the trait picker tooltip. -->
+  <RimWorldAccess.PawnFilter.TraitEffects>Effects: {0}.</RimWorldAccess.PawnFilter.TraitEffects>
+  <RimWorldAccess.PawnFilter.TraitCannotDo>Cannot do: {0}</RimWorldAccess.PawnFilter.TraitCannotDo>
   <RimWorldAccess.PawnFilter.WorkAllowNone>Allow none</RimWorldAccess.PawnFilter.WorkAllowNone>
 
   <!-- =================================================================

--- a/Languages/Russian/Keyed/RimWorldAccess_MainMenu.xml
+++ b/Languages/Russian/Keyed/RimWorldAccess_MainMenu.xml
@@ -759,4 +759,6 @@
   <RimWorldAccess.StartingPawn.AddPawn>Добавить персонажа</RimWorldAccess.StartingPawn.AddPawn>
   <RimWorldAccess.StartingPawn.RemovePawn>Убрать персонажа</RimWorldAccess.StartingPawn.RemovePawn>
 
+  <RimWorldAccess.PawnFilter.TraitEffects>Эффекты: {0}.</RimWorldAccess.PawnFilter.TraitEffects>
+  <RimWorldAccess.PawnFilter.TraitCannotDo>Не может: {0}</RimWorldAccess.PawnFilter.TraitCannotDo>
 </LanguageData>

--- a/Languages/SpanishLatin/Keyed/RimWorldAccess_MainMenu.xml
+++ b/Languages/SpanishLatin/Keyed/RimWorldAccess_MainMenu.xml
@@ -569,6 +569,8 @@
   <RimWorldAccess.PawnFilter.SectionConditions>Condiciones</RimWorldAccess.PawnFilter.SectionConditions>
   <RimWorldAccess.PawnFilter.SectionActions>Acciones</RimWorldAccess.PawnFilter.SectionActions>
   <RimWorldAccess.PawnFilter.TraitEntryFormat>{0}: {1} {2}</RimWorldAccess.PawnFilter.TraitEntryFormat>
+  <RimWorldAccess.PawnFilter.TraitEffects>Efectos: {0}.</RimWorldAccess.PawnFilter.TraitEffects>
+  <RimWorldAccess.PawnFilter.TraitCannotDo>No puede hacer: {0}</RimWorldAccess.PawnFilter.TraitCannotDo>
   <RimWorldAccess.PawnFilter.WorkAllowNone>No permitir ninguno</RimWorldAccess.PawnFilter.WorkAllowNone>
 
   <!-- =================================================================

--- a/Languages/Ukrainian/Keyed/RimWorldAccess_MainMenu.xml
+++ b/Languages/Ukrainian/Keyed/RimWorldAccess_MainMenu.xml
@@ -758,4 +758,6 @@
   <RimWorldAccess.StartingPawn.EditPawnFilter>Редагувати фільтр персонажів...</RimWorldAccess.StartingPawn.EditPawnFilter>
   <RimWorldAccess.StartingPawn.AddPawn>Додати персонажа</RimWorldAccess.StartingPawn.AddPawn>
   <RimWorldAccess.StartingPawn.RemovePawn>Видалити персонажа</RimWorldAccess.StartingPawn.RemovePawn>
+  <RimWorldAccess.PawnFilter.TraitEffects>Ефекти: {0}.</RimWorldAccess.PawnFilter.TraitEffects>
+  <RimWorldAccess.PawnFilter.TraitCannotDo>Не може: {0}</RimWorldAccess.PawnFilter.TraitCannotDo>
 </LanguageData>

--- a/src/MainMenu/PawnFilterHelper.cs
+++ b/src/MainMenu/PawnFilterHelper.cs
@@ -442,18 +442,28 @@ namespace RimWorldAccess
                     string desc = degree.description;
                     if (!string.IsNullOrEmpty(desc))
                     {
-                        // Convert {PAWN_*} to [PAWN_*] so GrammarResolver handles both formats
-                        desc = Regex.Replace(desc, @"\{(PAWN_\w+)\}", "[$1]");
+                        try
+                        {
+                            // Convert {PAWN_*} to [PAWN_*] so GrammarResolver handles both formats
+                            string resolvedDesc = Regex.Replace(desc, @"\{(PAWN_\w+)\}", "[$1]");
 
-                        // Resolve using game's grammar system with generic female colonist
-                        var request = default(GrammarRequest);
-                        request.Includes.Add(RulePackDefOf.DynamicWrapper);
-                        request.Rules.Add(new Rule_String("RULE", desc));
-                        request.Rules.AddRange(GrammarUtility.RulesForPawn(
-                            "PAWN", null, null, PawnKindDefOf.Colonist, Verse.Gender.Female,
-                            null, 25, 25, "", false, false, false, null, false, "",
-                            null, false));
-                        desc = GrammarResolver.Resolve("r_root", request);
+                            // Resolve using game's grammar system with generic female colonist
+                            var request = default(GrammarRequest);
+                            request.Includes.Add(RulePackDefOf.DynamicWrapper);
+                            request.Rules.Add(new Rule_String("RULE", resolvedDesc));
+                            request.Rules.AddRange(GrammarUtility.RulesForPawn(
+                                "PAWN", null, null, PawnKindDefOf.Colonist, Verse.Gender.Female,
+                                null, 25, 25, "", false, false, false, null, false, "",
+                                null, false));
+                            desc = GrammarResolver.Resolve("r_root", request);
+                        }
+                        catch (Exception)
+                        {
+                            // Some vanilla trait degree descriptions (e.g. Traits_Spectrum.xml)
+                            // null-ref inside GrammarResolver because no real pawn Name is
+                            // supplied above. Keep the raw description rather than aborting the
+                            // whole options list, which used to prevent the picker from opening.
+                        }
                     }
 
                     var option = new FloatMenuOption(label, () =>

--- a/src/MainMenu/PawnFilterHelper.cs
+++ b/src/MainMenu/PawnFilterHelper.cs
@@ -269,6 +269,40 @@ namespace RimWorldAccess
             return $"({"Male".Translate()}: {malePct:F1}%, {"Female".Translate()}: {femalePct:F1}%)";
         }
 
+        /// <summary>
+        /// Summarizes a trait degree's concrete gameplay effects (stat modifiers, skill gains,
+        /// disabled work) for the picker tooltip - the flavor description alone doesn't tell a
+        /// player what the trait actually does mechanically.
+        /// </summary>
+        private static string GetTraitDegreeEffectsSummary(TraitDef traitDef, TraitDegreeData degree)
+        {
+            var effects = new List<string>();
+
+            if (degree.statOffsets != null)
+                foreach (var so in degree.statOffsets)
+                    effects.Add($"{so.stat.LabelCap} {so.ValueToStringAsOffset}");
+
+            if (degree.statFactors != null)
+                foreach (var sf in degree.statFactors)
+                    effects.Add($"{sf.stat.LabelCap} {sf.ToStringAsFactor}");
+
+            if (degree.skillGains != null)
+                foreach (var gain in degree.skillGains)
+                    effects.Add($"{gain.skill.skillLabel.CapitalizeFirst()} {(gain.amount >= 0 ? "+" : "")}{gain.amount}");
+
+            if (traitDef.disabledWorkTags != WorkTags.None)
+            {
+                var tagLabels = traitDef.disabledWorkTags.GetAllSelectedItems<WorkTags>()
+                    .Where(t => t != WorkTags.None)
+                    .Select(t => t.LabelTranslated().CapitalizeFirst());
+                effects.Add(((string)"RimWorldAccess.PawnFilter.TraitCannotDo".Translate(string.Join(", ", tagLabels))));
+            }
+
+            return effects.Count > 0
+                ? (string)"RimWorldAccess.PawnFilter.TraitEffects".Translate(string.Join("; ", effects))
+                : "";
+        }
+
         public static string FormatSkillLabel(SkillFilter skill)
         {
             string skillName = skill.Skill.skillLabel.CapitalizeFirst();
@@ -444,15 +478,32 @@ namespace RimWorldAccess
                     {
                         try
                         {
-                            // Convert {PAWN_*} to [PAWN_*] so GrammarResolver handles both formats
-                            string resolvedDesc = Regex.Replace(desc, @"\{(PAWN_\w+)\}", "[$1]");
+                            // Some translations (notably Spanish) use a {PAWN_gender ? masc : fem}
+                            // ternary for grammatical gender agreement that predates/bypasses
+                            // GrammarResolver entirely - it's not [RULE] syntax, so left alone it
+                            // either throws inside Resolve() or (as here) is never touched by the
+                            // simple {PAWN_x} conversion below, leaking the raw "{PAWN_gender ? o :
+                            // a}" text verbatim. Resolve it ourselves first, picking the branch that
+                            // matches the fake pawn's gender (Male, see below) so it agrees with
+                            // GrammarResolver's own gender-dependent rules (e.g. [PAWN_pronoun]) and
+                            // with the generic "colono"-style fallback text it uses when no name is
+                            // supplied - both of which default to masculine regardless of the Gender
+                            // we pass, so mixing in a feminine branch here produced mismatched
+                            // agreement ("El colono es ... hermosa ... atraída a él").
+                            string resolvedDesc = Regex.Replace(
+                                desc,
+                                @"\{PAWN_gender\s*\?([^:{}]*):([^{}]*)\}",
+                                m => m.Groups[1].Value.Trim());
 
-                            // Resolve using game's grammar system with generic female colonist
+                            // Convert {PAWN_*} to [PAWN_*] so GrammarResolver handles both formats
+                            resolvedDesc = Regex.Replace(resolvedDesc, @"\{(PAWN_\w+)\}", "[$1]");
+
+                            // Resolve using game's grammar system with a generic male colonist
                             var request = default(GrammarRequest);
                             request.Includes.Add(RulePackDefOf.DynamicWrapper);
                             request.Rules.Add(new Rule_String("RULE", resolvedDesc));
                             request.Rules.AddRange(GrammarUtility.RulesForPawn(
-                                "PAWN", null, null, PawnKindDefOf.Colonist, Verse.Gender.Female,
+                                "PAWN", null, null, PawnKindDefOf.Colonist, Verse.Gender.Male,
                                 null, 25, 25, "", false, false, false, null, false, "",
                                 null, false));
                             desc = GrammarResolver.Resolve("r_root", request);
@@ -476,6 +527,10 @@ namespace RimWorldAccess
                         });
                         onTraitAdded?.Invoke();
                     });
+
+                    string effectsSummary = GetTraitDegreeEffectsSummary(traitDef, degree);
+                    if (!string.IsNullOrEmpty(effectsSummary))
+                        desc = string.IsNullOrEmpty(desc) ? effectsSummary : $"{desc} {effectsSummary}";
 
                     if (!string.IsNullOrEmpty(desc))
                         option.tooltip = new TipSignal(desc);


### PR DESCRIPTION
Alt+F → Add trait was crashing with a NullReferenceException for several vanilla TraitDefs (Nervous, Iron-willed, Industrious, etc.) because the description resolution needs a real pawn Name that isn't available in the filter context. The exception aborted the whole options list, so the picker never opened for any trait.

Wrapped the resolution in a try/catch so one bad description can't take down the rest of the list.

While testing, I also found the resolved descriptions had mismatched grammatical gender (e.g. "El colono es ... hermosa ... atraída a él") and were missing entirely for a translation quirk some languages (Spanish included) use for gender agreement (`{PAWN_gender ? masc : fem}`), which isn't grammar-resolver syntax and was leaking through raw or throwing. Fixed both, and while I was in there, added each trait's actual gameplay effects (stat changes, skill gains, disabled work) after the flavor text, since the description alone doesn't tell you what a trait does mechanically.

Closes #117