### PR TITLE
fix: repair broken Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Screen reader accessibility for RimWorld. Uses the Tolk library to communicate with NVDA, JAWS, and other screen readers. Falls back to Windows SAPI if no screen reader is detected.
 
-> **Note:** This mod is an early version. Errors may be present. This documentation is a rough overview—for detailed questions and clarifications, join the [Discord server](https://discord.gg/Aecaqnbr).
+> **Note:** This mod is an early version. Errors may be present. This documentation is a rough overview—for detailed questions and clarifications, join the [Discord server](https://discord.gg/XdxfyvSKaT).
 
 > **Bug Reports:** Bug reports involving mods other than RimWorld Access are currently unsupported. Please test with only Harmony and RimWorld Access enabled before reporting issues.
 

--- a/docs-site/docs/starting/world-map-site.md
+++ b/docs-site/docs/starting/world-map-site.md
@@ -10,7 +10,6 @@ A few shortcuts make navigation faster:
 
 - **R** jumps the cursor to a random valid starting tile and reads its details. A generated world holds tens of thousands of tiles, so this lands you somewhere new each time you press it.
 - **Space** re-announces the current tile.
-- **Ctrl+Up/Down/Left/Right** jumps to the next biome boundary in that direction, useful for finding the edge of a desert or the start of a forest.
 
 ## Reading tile details
 


### PR DESCRIPTION
The README's intro note pointed at an expired Discord invite (discord.gg/Aecaqnbr, comes back "Unknown Invite" from Discord's API), while the working invite (discord.gg/XdxfyvSKaT) was already used elsewhere in the same file. Pointed both at the working one.

I also checked the other two things mentioned in #93:
- The mod-list reorder keys (Ctrl+Up/Down) already match current code — ModListState was simplified off Ctrl+Shift in a later refactor, so that part of the report is stale.
- The claim that Ctrl+Up/Down/Left/Right jumps to the next biome boundary on the starting-site world map wasn't true when I checked, so I removed it from docs-site — but since it seemed like a genuinely useful shortcut, I implemented it for real in a separate PR instead of just deleting the claim.

Closes #93