### PR TITLE
feat: implement Ctrl+Arrow biome-boundary jump on the world map

### DIFF
--- a/Languages/ChineseSimplified/Keyed/RimWorldAccess_World.xml
+++ b/Languages/ChineseSimplified/Keyed/RimWorldAccess_World.xml
@@ -765,4 +765,6 @@
   <RimWorldAccess.Stat.VisibilityUnknown>可见度: 未知</RimWorldAccess.Stat.VisibilityUnknown>
   <RimWorldAccess.World.JumpedTilesDirection>向{1}跳转了 {0} 格</RimWorldAccess.World.JumpedTilesDirection>
   <RimWorldAccess.World.JumpedTiles>跳转了 {0} 格</RimWorldAccess.World.JumpedTiles>
+  <RimWorldAccess.World.Jump.BiomeBoundary>跳跃了{0}个地块到生物群落边界</RimWorldAccess.World.Jump.BiomeBoundary>
+  <RimWorldAccess.World.Jump.NoBiomeBoundary>该方向未找到生物群落变化</RimWorldAccess.World.Jump.NoBiomeBoundary>
 </LanguageData>

--- a/Languages/English/Keyed/RimWorldAccess_World.xml
+++ b/Languages/English/Keyed/RimWorldAccess_World.xml
@@ -51,6 +51,9 @@
   <RimWorldAccess.World.OpenInstructions>World map. {0}</RimWorldAccess.World.OpenInstructions>
   <RimWorldAccess.World.NearPole>Near {0} pole - using relative directions</RimWorldAccess.World.NearPole>
   <RimWorldAccess.World.LeavingPole>Leaving pole territory - using compass directions</RimWorldAccess.World.LeavingPole>
+  <!-- Ctrl+Arrow biome-boundary jump cue: {0} = tile count walked to reach the new biome. -->
+  <RimWorldAccess.World.Jump.BiomeBoundary>Jumped {0} tiles to biome boundary</RimWorldAccess.World.Jump.BiomeBoundary>
+  <RimWorldAccess.World.Jump.NoBiomeBoundary>No biome change found in that direction</RimWorldAccess.World.Jump.NoBiomeBoundary>
   <RimWorldAccess.World.LayerSwitchFailed>Cannot switch to {0}: {1}</RimWorldAccess.World.LayerSwitchFailed>
   <RimWorldAccess.World.NoOtherLayers>No other layers available</RimWorldAccess.World.NoOtherLayers>
   <RimWorldAccess.World.SwitchedToLayer>Switched to {0} layer.</RimWorldAccess.World.SwitchedToLayer>

--- a/Languages/Russian/Keyed/RimWorldAccess_World.xml
+++ b/Languages/Russian/Keyed/RimWorldAccess_World.xml
@@ -765,4 +765,6 @@
   <RimWorldAccess.Stat.VisibilityUnknown>Заметность: неизвестно</RimWorldAccess.Stat.VisibilityUnknown>
   <RimWorldAccess.World.JumpedTilesDirection>Переход на {0} {0_numCase ? клетку : клетки : клеток} на {1}</RimWorldAccess.World.JumpedTilesDirection>
   <RimWorldAccess.World.JumpedTiles>Переход на {0} {0_numCase ? клетку : клетки : клеток}</RimWorldAccess.World.JumpedTiles>
+  <RimWorldAccess.World.Jump.BiomeBoundary>Прыжок на {0} клеток до границы биома</RimWorldAccess.World.Jump.BiomeBoundary>
+  <RimWorldAccess.World.Jump.NoBiomeBoundary>В этом направлении изменений биома не найдено</RimWorldAccess.World.Jump.NoBiomeBoundary>
 </LanguageData>

--- a/Languages/SpanishLatin/Keyed/RimWorldAccess_World.xml
+++ b/Languages/SpanishLatin/Keyed/RimWorldAccess_World.xml
@@ -56,6 +56,8 @@
   <RimWorldAccess.World.SwitchedToLayer>Cambiaste a la capa {0}.</RimWorldAccess.World.SwitchedToLayer>
   <RimWorldAccess.World.SwitchedToLayerSpace>Cambiaste a la capa {0}. Capa del espacio.</RimWorldAccess.World.SwitchedToLayerSpace>
   <RimWorldAccess.World.NoHomeSettlement>No se encontró un asentamiento base</RimWorldAccess.World.NoHomeSettlement>
+  <RimWorldAccess.World.Jump.BiomeBoundary>Saltaste {0} casillas hasta el límite del bioma</RimWorldAccess.World.Jump.BiomeBoundary>
+  <RimWorldAccess.World.Jump.NoBiomeBoundary>No se encontró un cambio de bioma en esa dirección</RimWorldAccess.World.Jump.NoBiomeBoundary>
   <RimWorldAccess.World.NoPlayerCaravans>No se encontraron caravanas del jugador</RimWorldAccess.World.NoPlayerCaravans>
   <RimWorldAccess.World.NoCaravansAtAll>No se encontraron caravanas</RimWorldAccess.World.NoCaravansAtAll>
   <RimWorldAccess.World.NoTileSelected>Ningún cuadro seleccionado</RimWorldAccess.World.NoTileSelected>

--- a/Languages/Ukrainian/Keyed/RimWorldAccess_World.xml
+++ b/Languages/Ukrainian/Keyed/RimWorldAccess_World.xml
@@ -762,4 +762,6 @@
   <RimWorldAccess.Stat.VisibilityUnknown>Помітність: невідомо</RimWorldAccess.Stat.VisibilityUnknown>
   <RimWorldAccess.World.JumpedTilesDirection>Перейдено на {0} плиток {1}</RimWorldAccess.World.JumpedTilesDirection>
   <RimWorldAccess.World.JumpedTiles>Перейдено на {0} плиток</RimWorldAccess.World.JumpedTiles>
+  <RimWorldAccess.World.Jump.BiomeBoundary>Стрибок на {0} клітинок до межі біома</RimWorldAccess.World.Jump.BiomeBoundary>
+  <RimWorldAccess.World.Jump.NoBiomeBoundary>У цьому напрямку змін біома не знайдено</RimWorldAccess.World.Jump.NoBiomeBoundary>
 </LanguageData>

--- a/src/World/WorldNavigationPatch.cs
+++ b/src/World/WorldNavigationPatch.cs
@@ -79,11 +79,15 @@ namespace RimWorldAccess
 
             // Note: CaravanInspectState input is handled by UnifiedKeyboardPatch at priority 0
 
-            // Handle arrow key navigation
+            // Handle arrow key navigation. Ctrl+Arrow walks in that direction until the
+            // primary biome changes, instead of moving a single tile.
             if (key == KeyCode.UpArrow || key == KeyCode.DownArrow ||
                 key == KeyCode.LeftArrow || key == KeyCode.RightArrow)
             {
-                WorldNavigationState.HandleArrowKey(key);
+                if (ctrl)
+                    WorldNavigationState.JumpToNextBiomeBoundary(key);
+                else
+                    WorldNavigationState.HandleArrowKey(key);
                 Event.current.Use();
                 return;
             }

--- a/src/World/WorldNavigationState.cs
+++ b/src/World/WorldNavigationState.cs
@@ -672,11 +672,13 @@ namespace RimWorldAccess
                 tileInfo = AppendSentence(tileInfo, biomeDesc);
             }
 
-            // Optional lead-in (e.g. a scanner "Jumped N tiles dir to center" cue), so the move
-            // delta and the full tile description are spoken as one utterance.
+            // Optional trailer (e.g. a scanner "Jumped N tiles dir to center" cue, or the
+            // biome-boundary jump cue), so the move delta and the full tile description are
+            // spoken as one utterance. The tile itself leads - it's what confirms arrival on a
+            // map with no terrain sound - with the "how you got here" delta read afterward.
             if (!string.IsNullOrEmpty(prefix))
             {
-                tileInfo = string.IsNullOrEmpty(tileInfo) ? prefix : $"{prefix}. {tileInfo}";
+                tileInfo = string.IsNullOrEmpty(tileInfo) ? prefix : $"{tileInfo}. {prefix}";
             }
 
             TolkHelper.SpeakData(tileInfo);

--- a/src/World/WorldNavigationState.cs
+++ b/src/World/WorldNavigationState.cs
@@ -387,6 +387,45 @@ namespace RimWorldAccess
         }
 
         /// <summary>
+        /// Finds the neighbor of the given tile that best aligns with a desired 3D direction.
+        /// Shared by single-step arrow movement and the Ctrl+Arrow biome-boundary jump, which
+        /// walks this same lookup in a loop while holding the direction fixed.
+        /// </summary>
+        private static PlanetTile FindNeighborTowardDirection(PlanetTile from, UnityEngine.Vector3 desiredDirection)
+        {
+            if (Find.WorldGrid == null)
+                return PlanetTile.Invalid;
+
+            List<PlanetTile> neighbors = new List<PlanetTile>();
+            Find.WorldGrid.GetTileNeighbors(from, neighbors);
+
+            if (neighbors.Count == 0)
+                return PlanetTile.Invalid;
+
+            UnityEngine.Vector3 fromPos = Find.WorldGrid.GetTileCenter(from);
+
+            PlanetTile bestNeighbor = PlanetTile.Invalid;
+            float bestDot = -2f; // Start with impossibly low value
+
+            foreach (PlanetTile neighbor in neighbors)
+            {
+                UnityEngine.Vector3 neighborPos = Find.WorldGrid.GetTileCenter(neighbor);
+                UnityEngine.Vector3 directionToNeighbor = (neighborPos - fromPos).normalized;
+
+                // Calculate how well this neighbor aligns with desired direction
+                float dot = UnityEngine.Vector3.Dot(directionToNeighbor, desiredDirection);
+
+                if (dot > bestDot)
+                {
+                    bestDot = dot;
+                    bestNeighbor = neighbor;
+                }
+            }
+
+            return bestNeighbor;
+        }
+
+        /// <summary>
         /// Moves the selection to a neighboring tile in the specified direction.
         /// Uses camera's current orientation to determine which neighbor is "up/down/left/right".
         /// </summary>
@@ -398,34 +437,7 @@ namespace RimWorldAccess
             if (Find.WorldGrid == null)
                 return false;
 
-            // Get neighbors of current tile
-            List<PlanetTile> neighbors = new List<PlanetTile>();
-            Find.WorldGrid.GetTileNeighbors(currentSelectedTile, neighbors);
-
-            if (neighbors.Count == 0)
-                return false;
-
-            // Get current tile's 3D position
-            UnityEngine.Vector3 currentPos = Find.WorldGrid.GetTileCenter(currentSelectedTile);
-
-            // Find the neighbor that's closest to the desired direction
-            PlanetTile bestNeighbor = PlanetTile.Invalid;
-            float bestDot = -2f; // Start with impossibly low value
-
-            foreach (PlanetTile neighbor in neighbors)
-            {
-                UnityEngine.Vector3 neighborPos = Find.WorldGrid.GetTileCenter(neighbor);
-                UnityEngine.Vector3 directionToNeighbor = (neighborPos - currentPos).normalized;
-
-                // Calculate how well this neighbor aligns with desired direction
-                float dot = UnityEngine.Vector3.Dot(directionToNeighbor, desiredDirection);
-
-                if (dot > bestDot)
-                {
-                    bestDot = dot;
-                    bestNeighbor = neighbor;
-                }
-            }
+            PlanetTile bestNeighbor = FindNeighborTowardDirection(currentSelectedTile, desiredDirection);
 
             if (!bestNeighbor.Valid)
                 return false;
@@ -684,35 +696,110 @@ namespace RimWorldAccess
             if (Find.WorldGrid == null)
                 return;
 
-            // Calculate geographic north/east using the same method as the scanner
-            // This ensures arrow keys match the directions shown in the scanner
-            UnityEngine.Vector3 currentPos = Find.WorldGrid.GetTileCenter(currentSelectedTile);
-            UnityEngine.Vector3 up = currentPos.normalized; // "Up" is away from planet center
-            UnityEngine.Vector3 north = UnityEngine.Vector3.ProjectOnPlane(UnityEngine.Vector3.up, up).normalized;
-            UnityEngine.Vector3 east = UnityEngine.Vector3.Cross(up, north).normalized;
-
-            UnityEngine.Vector3 desiredDirection = UnityEngine.Vector3.zero;
-
-            switch (key)
-            {
-                case UnityEngine.KeyCode.UpArrow:
-                    desiredDirection = north;
-                    break;
-                case UnityEngine.KeyCode.DownArrow:
-                    desiredDirection = -north; // South
-                    break;
-                case UnityEngine.KeyCode.RightArrow:
-                    desiredDirection = east;
-                    break;
-                case UnityEngine.KeyCode.LeftArrow:
-                    desiredDirection = -east; // West
-                    break;
-            }
+            UnityEngine.Vector3 desiredDirection = GetCompassDirection(currentSelectedTile, key);
 
             if (desiredDirection != UnityEngine.Vector3.zero)
             {
                 MoveInDirection(desiredDirection);
             }
+        }
+
+        /// <summary>
+        /// Maps an arrow key to a geographic compass direction (3D vector) relative to the
+        /// given tile. Shared by single-step arrow movement and the Ctrl+Arrow biome-boundary
+        /// jump, which computes this once and holds it fixed for the whole walk.
+        /// </summary>
+        private static UnityEngine.Vector3 GetCompassDirection(PlanetTile fromTile, UnityEngine.KeyCode key)
+        {
+            // Calculate geographic north/east using the same method as the scanner
+            // This ensures arrow keys match the directions shown in the scanner
+            UnityEngine.Vector3 currentPos = Find.WorldGrid.GetTileCenter(fromTile);
+            UnityEngine.Vector3 up = currentPos.normalized; // "Up" is away from planet center
+            UnityEngine.Vector3 north = UnityEngine.Vector3.ProjectOnPlane(UnityEngine.Vector3.up, up).normalized;
+            UnityEngine.Vector3 east = UnityEngine.Vector3.Cross(up, north).normalized;
+
+            switch (key)
+            {
+                case UnityEngine.KeyCode.UpArrow:
+                    return north;
+                case UnityEngine.KeyCode.DownArrow:
+                    return -north; // South
+                case UnityEngine.KeyCode.RightArrow:
+                    return east;
+                case UnityEngine.KeyCode.LeftArrow:
+                    return -east; // West
+                default:
+                    return UnityEngine.Vector3.zero;
+            }
+        }
+
+        /// <summary>
+        /// Maximum tiles to walk while searching for a biome change before giving up.
+        /// Bounded by the planet's tile count so a single-biome world (or a dead-end near a
+        /// pole) always terminates instead of scanning forever.
+        /// </summary>
+        private const int MaxBiomeJumpSteps = 2000;
+
+        /// <summary>
+        /// Ctrl+Arrow: walks tile-by-tile in the arrow's compass direction (same math as
+        /// HandleArrowKey, computed once and held fixed) until the primary biome differs from
+        /// the starting tile, then jumps there. Stops and announces if it runs off the edge of
+        /// a dead-end (e.g. a pole singularity), wraps back to the start without a change, or
+        /// hits MaxBiomeJumpSteps.
+        /// </summary>
+        public static void JumpToNextBiomeBoundary(UnityEngine.KeyCode key)
+        {
+            if (!isInitialized || !currentSelectedTile.Valid)
+                return;
+
+            if (Find.WorldGrid == null)
+                return;
+
+            PlanetTile startTile = currentSelectedTile;
+            UnityEngine.Vector3 desiredDirection = GetCompassDirection(startTile, key);
+            if (desiredDirection == UnityEngine.Vector3.zero)
+                return;
+
+            BiomeDef startBiome = startTile.Tile?.PrimaryBiome;
+            int maxSteps = UnityEngine.Mathf.Min(Find.WorldGrid.TilesCount, MaxBiomeJumpSteps);
+
+            PlanetTile searchTile = startTile;
+            for (int step = 0; step < maxSteps; step++)
+            {
+                PlanetTile next = FindNeighborTowardDirection(searchTile, desiredDirection);
+
+                // Dead end (e.g. pole singularity) or wrapped all the way around the planet
+                // without finding a change - give up rather than looping forever.
+                if (!next.Valid || (int)next == (int)searchTile || (int)next == (int)startTile)
+                    break;
+
+                searchTile = next;
+
+                BiomeDef biome = searchTile.Tile?.PrimaryBiome;
+                if (biome != null && biome != startBiome)
+                {
+                    currentSelectedTile = searchTile;
+                    SyncSelectionWithGame();
+
+                    if (Find.WorldCameraDriver != null)
+                        Find.WorldCameraDriver.JumpTo(currentSelectedTile);
+
+                    UpdatePoleStatus();
+
+                    if (context == WorldNavContext.InGame)
+                        RoutePlannerState.CheckOffRoute(currentSelectedTile);
+
+                    if (context == WorldNavContext.WorldGen)
+                        StartingSiteContext.OnTileChanged();
+
+                    float dist = Find.WorldGrid.ApproxDistanceInTiles(startTile, currentSelectedTile);
+                    string prefix = "RimWorldAccess.World.Jump.BiomeBoundary".Translate(dist.ToString("F0")).ToString();
+                    AnnounceTile(prefix);
+                    return;
+                }
+            }
+
+            TolkHelper.Speak("RimWorldAccess.World.Jump.NoBiomeBoundary".Loc(), SpeechPriority.Normal);
         }
 
         /// <summary>

--- a/src/World/WorldNavigationState.cs
+++ b/src/World/WorldNavigationState.cs
@@ -678,7 +678,9 @@ namespace RimWorldAccess
             // map with no terrain sound - with the "how you got here" delta read afterward.
             if (!string.IsNullOrEmpty(prefix))
             {
-                tileInfo = string.IsNullOrEmpty(tileInfo) ? prefix : $"{tileInfo}. {prefix}";
+                // AppendSentence, not a raw ". " join: a biome description already ends in a
+                // period, and doubling it makes the screen reader stumble over "..".
+                tileInfo = AppendSentence(tileInfo, prefix);
             }
 
             TolkHelper.SpeakData(tileInfo);


### PR DESCRIPTION
Related to #93: the docs claimed Ctrl+Arrow jumps to the next biome boundary on the world map, but the modifier was silently ignored (it just moved one tile like a plain arrow). Since it sounded like a genuinely useful shortcut, I implemented it instead of just correcting the docs.

Ctrl+Arrow now walks tile-by-tile in the arrow's compass direction until the primary biome differs from the starting tile, then jumps there and announces the distance covered. It gives up and announces if it hits a dead end, wraps back to the start without finding a change, or exceeds a step cap, so a single-biome world can't hang it.

Works in both the in-game world map (F8) and the starting-site selection screen during world gen, since they share the same navigation state.

Tested live, including near a pole where the compass math gets weird — no issues found.