### PR TITLE
feat: show pen status for penned animals

### DIFF
--- a/Languages/ChineseSimplified/Keyed/RimWorldAccess_Animals.xml
+++ b/Languages/ChineseSimplified/Keyed/RimWorldAccess_Animals.xml
@@ -226,4 +226,9 @@
        ValueOnly: {0} = value, {1} = position. -->
   <RimWorldAccess.Animals.AutoSlaughter.Cell.NameWithoutColumn>{0}: {1}. {2}</RimWorldAccess.Animals.AutoSlaughter.Cell.NameWithoutColumn>
   <RimWorldAccess.Animals.AutoSlaughter.Cell.ValueOnly>{0}. {1}</RimWorldAccess.Animals.AutoSlaughter.Cell.ValueOnly>
+  <RimWorldAccess.Animals.Value.InPen>在畜栏内</RimWorldAccess.Animals.Value.InPen>
+  <RimWorldAccess.Animals.Value.OutsidePen>在畜栏外</RimWorldAccess.Animals.Value.OutsidePen>
+  <RimWorldAccess.Animals.Value.NoPenAssigned>未分配畜栏</RimWorldAccess.Animals.Value.NoPenAssigned>
+  <RimWorldAccess.Animals.Value.PenNotNeeded>不需要畜栏</RimWorldAccess.Animals.Value.PenNotNeeded>
+  <RimWorldAccess.Animals.Column.PenStatus>畜栏状态</RimWorldAccess.Animals.Column.PenStatus>
 </LanguageData>

--- a/Languages/English/Keyed/RimWorldAccess_Animals.xml
+++ b/Languages/English/Keyed/RimWorldAccess_Animals.xml
@@ -35,6 +35,10 @@
   <!-- BondBroken is wrapped in parentheses after the "Bonded to X" text. -->
   <RimWorldAccess.Animals.Value.BondBroken>bond broken</RimWorldAccess.Animals.Value.BondBroken>
   <RimWorldAccess.Animals.Value.Scheduled>Scheduled</RimWorldAccess.Animals.Value.Scheduled>
+  <!-- PenStatus column values (AnimalsMenuHelper.GetPenStatus). -->
+  <RimWorldAccess.Animals.Value.InPen>in pen</RimWorldAccess.Animals.Value.InPen>
+  <RimWorldAccess.Animals.Value.OutsidePen>outside pen</RimWorldAccess.Animals.Value.OutsidePen>
+  <RimWorldAccess.Animals.Value.NoPenAssigned>no pen assigned</RimWorldAccess.Animals.Value.NoPenAssigned>
 
   <!-- Paint value labels. AnimalsMenuHelper.GetPaintValueLabel and
        WildlifeMenuHelper.GetPaintValueLabel return these for checkbox
@@ -56,6 +60,7 @@
   <RimWorldAccess.Animals.Column.BondInfo>Bond</RimWorldAccess.Animals.Column.BondInfo>
   <RimWorldAccess.Animals.Column.Sterile>Sterile</RimWorldAccess.Animals.Column.Sterile>
   <RimWorldAccess.Animals.Column.MedicalCare>Medical care</RimWorldAccess.Animals.Column.MedicalCare>
+  <RimWorldAccess.Animals.Column.PenStatus>Pen status</RimWorldAccess.Animals.Column.PenStatus>
 
   <!-- =================================================================
        Training status (AnimalsMenuHelper.GetTrainingStatus and

--- a/Languages/English/Keyed/RimWorldAccess_Animals.xml
+++ b/Languages/English/Keyed/RimWorldAccess_Animals.xml
@@ -39,6 +39,7 @@
   <RimWorldAccess.Animals.Value.InPen>in pen</RimWorldAccess.Animals.Value.InPen>
   <RimWorldAccess.Animals.Value.OutsidePen>outside pen</RimWorldAccess.Animals.Value.OutsidePen>
   <RimWorldAccess.Animals.Value.NoPenAssigned>no pen assigned</RimWorldAccess.Animals.Value.NoPenAssigned>
+  <RimWorldAccess.Animals.Value.PenNotNeeded>does not need a pen</RimWorldAccess.Animals.Value.PenNotNeeded>
 
   <!-- Paint value labels. AnimalsMenuHelper.GetPaintValueLabel and
        WildlifeMenuHelper.GetPaintValueLabel return these for checkbox

--- a/Languages/Russian/Keyed/RimWorldAccess_Animals.xml
+++ b/Languages/Russian/Keyed/RimWorldAccess_Animals.xml
@@ -227,4 +227,9 @@
        ValueOnly: {0} = value, {1} = position. -->
   <RimWorldAccess.Animals.AutoSlaughter.Cell.NameWithoutColumn>{0}: {1}. {2}</RimWorldAccess.Animals.AutoSlaughter.Cell.NameWithoutColumn>
   <RimWorldAccess.Animals.AutoSlaughter.Cell.ValueOnly>{0}. {1}</RimWorldAccess.Animals.AutoSlaughter.Cell.ValueOnly>
+  <RimWorldAccess.Animals.Value.InPen>в загоне</RimWorldAccess.Animals.Value.InPen>
+  <RimWorldAccess.Animals.Value.OutsidePen>вне загона</RimWorldAccess.Animals.Value.OutsidePen>
+  <RimWorldAccess.Animals.Value.NoPenAssigned>загон не назначен</RimWorldAccess.Animals.Value.NoPenAssigned>
+  <RimWorldAccess.Animals.Value.PenNotNeeded>загон не требуется</RimWorldAccess.Animals.Value.PenNotNeeded>
+  <RimWorldAccess.Animals.Column.PenStatus>Статус загона</RimWorldAccess.Animals.Column.PenStatus>
 </LanguageData>

--- a/Languages/SpanishLatin/Keyed/RimWorldAccess_Animals.xml
+++ b/Languages/SpanishLatin/Keyed/RimWorldAccess_Animals.xml
@@ -42,6 +42,11 @@
   <RimWorldAccess.Animals.Paint.Checked>marcado</RimWorldAccess.Animals.Paint.Checked>
   <RimWorldAccess.Animals.Paint.Unchecked>desmarcado</RimWorldAccess.Animals.Paint.Unchecked>
 
+  <!-- PenStatus column values (AnimalsMenuHelper.GetPenStatus). -->
+  <RimWorldAccess.Animals.Value.InPen>en el corral</RimWorldAccess.Animals.Value.InPen>
+  <RimWorldAccess.Animals.Value.OutsidePen>fuera del corral</RimWorldAccess.Animals.Value.OutsidePen>
+  <RimWorldAccess.Animals.Value.NoPenAssigned>sin corral asignado</RimWorldAccess.Animals.Value.NoPenAssigned>
+
   <!-- =================================================================
        AnimalsMenuHelper column headers (colony animals tab).
        "Name" and "Age" are hard-coded English labels that don't have
@@ -56,6 +61,7 @@
   <RimWorldAccess.Animals.Column.BondInfo>Vínculo</RimWorldAccess.Animals.Column.BondInfo>
   <RimWorldAccess.Animals.Column.Sterile>Estéril</RimWorldAccess.Animals.Column.Sterile>
   <RimWorldAccess.Animals.Column.MedicalCare>Atención médica</RimWorldAccess.Animals.Column.MedicalCare>
+  <RimWorldAccess.Animals.Column.PenStatus>Estado del corral</RimWorldAccess.Animals.Column.PenStatus>
 
   <!-- =================================================================
        Training status (AnimalsMenuHelper.GetTrainingStatus and

--- a/Languages/SpanishLatin/Keyed/RimWorldAccess_Animals.xml
+++ b/Languages/SpanishLatin/Keyed/RimWorldAccess_Animals.xml
@@ -46,6 +46,7 @@
   <RimWorldAccess.Animals.Value.InPen>en el corral</RimWorldAccess.Animals.Value.InPen>
   <RimWorldAccess.Animals.Value.OutsidePen>fuera del corral</RimWorldAccess.Animals.Value.OutsidePen>
   <RimWorldAccess.Animals.Value.NoPenAssigned>sin corral asignado</RimWorldAccess.Animals.Value.NoPenAssigned>
+  <RimWorldAccess.Animals.Value.PenNotNeeded>no necesita corral</RimWorldAccess.Animals.Value.PenNotNeeded>
 
   <!-- =================================================================
        AnimalsMenuHelper column headers (colony animals tab).

--- a/Languages/Ukrainian/Keyed/RimWorldAccess_Animals.xml
+++ b/Languages/Ukrainian/Keyed/RimWorldAccess_Animals.xml
@@ -222,4 +222,9 @@
   <RimWorldAccess.Animals.AutoSlaughter.Numeric.Empty>Порожньо</RimWorldAccess.Animals.AutoSlaughter.Numeric.Empty>
   <RimWorldAccess.Animals.AutoSlaughter.Numeric.Invalid>Недійсне число. Використовуйте мінус 1 для необмеженого значення</RimWorldAccess.Animals.AutoSlaughter.Numeric.Invalid>
   <RimWorldAccess.Animals.AutoSlaughter.Numeric.Cancelled>Скасовано</RimWorldAccess.Animals.AutoSlaughter.Numeric.Cancelled>
+  <RimWorldAccess.Animals.Value.InPen>у загоні</RimWorldAccess.Animals.Value.InPen>
+  <RimWorldAccess.Animals.Value.OutsidePen>поза загоном</RimWorldAccess.Animals.Value.OutsidePen>
+  <RimWorldAccess.Animals.Value.NoPenAssigned>загін не призначено</RimWorldAccess.Animals.Value.NoPenAssigned>
+  <RimWorldAccess.Animals.Value.PenNotNeeded>загін не потрібен</RimWorldAccess.Animals.Value.PenNotNeeded>
+  <RimWorldAccess.Animals.Column.PenStatus>Статус загону</RimWorldAccess.Animals.Column.PenStatus>
 </LanguageData>

--- a/src/Animals/AnimalsMenuHelper.cs
+++ b/src/Animals/AnimalsMenuHelper.cs
@@ -31,7 +31,8 @@ namespace RimWorldAccess
             Slaughter,
             MedicalCare,
             ReleaseToWild,
-            AllowedArea
+            AllowedArea,
+            PenStatus
         }
 
         private static List<TrainableDef> cachedTrainables = null;
@@ -125,6 +126,7 @@ namespace RimWorldAccess
             columns.Add(ColumnType.MedicalCare);
             columns.Add(ColumnType.ReleaseToWild);
             columns.Add(ColumnType.AllowedArea);
+            columns.Add(ColumnType.PenStatus);
 
             return columns;
         }
@@ -226,6 +228,7 @@ namespace RimWorldAccess
                 case ColumnType.MedicalCare: return "RimWorldAccess.Animals.Column.MedicalCare".Translate().Resolve();
                 case ColumnType.ReleaseToWild: return "DesignatorReleaseAnimalToWild".Translate().Resolve();
                 case ColumnType.AllowedArea: return "AllowedArea".Translate().Resolve();
+                case ColumnType.PenStatus: return "RimWorldAccess.Animals.Column.PenStatus".Translate().Resolve();
                 default: return type.ToString().Replace("_", " ");
             }
         }
@@ -335,9 +338,24 @@ namespace RimWorldAccess
                     return GetReleaseToWildStatus(pawn);
                 case ColumnType.AllowedArea:
                     return GetAllowedArea(pawn);
+                case ColumnType.PenStatus:
+                    return GetPenStatus(pawn);
                 default:
                     return "RimWorldAccess.Animals.Value.Unknown".Translate().ToString();
             }
+        }
+
+        public static string GetPenStatus(Pawn pawn)
+        {
+            CompAnimalPenMarker pen = AnimalPenUtility.GetCurrentPenOf(pawn, allowUnenclosedPens: true);
+            if (pen == null)
+                return "RimWorldAccess.Animals.Value.NoPenAssigned".Translate().ToString();
+
+            Region pawnRegion = pawn.GetRegion();
+            bool inPen = pawnRegion != null && pen.PenState.ContainsConnectedRegion(pawnRegion);
+            return inPen
+                ? "RimWorldAccess.Animals.Value.InPen".Translate().ToString()
+                : "RimWorldAccess.Animals.Value.OutsidePen".Translate().ToString();
         }
 
         // Check if column is interactive (can be changed with Enter key)

--- a/src/Animals/AnimalsMenuHelper.cs
+++ b/src/Animals/AnimalsMenuHelper.cs
@@ -347,6 +347,12 @@ namespace RimWorldAccess
 
         public static string GetPenStatus(Pawn pawn)
         {
+            // Most tame animals — dogs, cats, squirrels — never belong to a pen. Saying "no pen
+            // assigned" for them reads as a setup the player forgot, so answer the prior question
+            // first: does this animal need penning at all?
+            if (!AnimalPenUtility.NeedsToBeManagedByRope(pawn))
+                return "RimWorldAccess.Animals.Value.PenNotNeeded".Translate().ToString();
+
             CompAnimalPenMarker pen = AnimalPenUtility.GetCurrentPenOf(pawn, allowUnenclosedPens: true);
             if (pen == null)
                 return "RimWorldAccess.Animals.Value.NoPenAssigned".Translate().ToString();

--- a/src/Animals/CLAUDE.md
+++ b/src/Animals/CLAUDE.md
@@ -54,7 +54,8 @@ Both menus use `TabularMenuHelper<Pawn>` (from UI module) for shared navigation:
 - Cell announcement building
 
 ### AnimalsMenuState (Colony Animals)
-- 14+ columns (Name, Bond, Master, Slaughter, training columns, etc.)
+- 15+ columns (Name, Bond, Master, Slaughter, Pen Status, training columns, etc.)
+- **Pen Status** column (last column): read-only. `AnimalsMenuHelper.GetPenStatus` calls `AnimalPenUtility.GetCurrentPenOf` for the animal's assigned pen, then checks `CompAnimalPenMarker.PenState.ContainsConnectedRegion(pawn.GetRegion())` to report "in pen" / "outside pen" / "no pen assigned"
 - Dynamic training columns based on TrainableDef
 - Submenu system for Master, AllowedArea, MedicalCare, FoodRestriction
 - Default sort: Name ascending


### PR DESCRIPTION
The animals menu (F4) had no way to tell whether a penned animal was actually inside its assigned pen or had wandered/escaped, making it hard to notice animals that need to be brought back.

Added a read-only "Pen Status" column reporting "in pen" / "outside pen" / "no pen assigned" per animal, using the same pen-assignment and region-containment APIs the game itself uses (AnimalPenUtility.GetCurrentPenOf + PenMarkerState.ContainsConnectedRegion), so it holds up correctly for unroofed/open-air pens rather than relying on a room-equality guess.

Closes #71