### PR TITLE
fix: restore hediff severity and immunity progress display

### DIFF
--- a/Languages/ChineseSimplified/Keyed/RimWorldAccess_Pawns.xml
+++ b/Languages/ChineseSimplified/Keyed/RimWorldAccess_Pawns.xml
@@ -575,6 +575,7 @@
   <RimWorldAccess.Pawns.Health.NameHeader>{0}</RimWorldAccess.Pawns.Health.NameHeader>
   <RimWorldAccess.Pawns.Health.Capacity>{0}: {1}</RimWorldAccess.Pawns.Health.Capacity>
   <RimWorldAccess.Pawns.Health.PartHealth>{0}: {1}/{2}</RimWorldAccess.Pawns.Health.PartHealth>
+  <RimWorldAccess.Pawns.Health.Severity>严重程度</RimWorldAccess.Pawns.Health.Severity>
 
   <!-- Needs. -->
   <RimWorldAccess.Pawns.Needs.NoTracker>{0}: 无需求追踪器</RimWorldAccess.Pawns.Needs.NoTracker>

--- a/Languages/English/Keyed/RimWorldAccess_Pawns.xml
+++ b/Languages/English/Keyed/RimWorldAccess_Pawns.xml
@@ -576,6 +576,10 @@
   <RimWorldAccess.Pawns.Health.Capacity>{0}: {1}</RimWorldAccess.Pawns.Health.Capacity>
   <RimWorldAccess.Pawns.Health.PartHealth>{0}: {1}/{2}</RimWorldAccess.Pawns.Health.PartHealth>
 
+  <!-- Hediff detail line prefix for vanilla's Hediff.SeverityLabel (e.g. "Severity: 54%"),
+       used in the inspection tree's hediff detail children (HealthTabHelper.GetComprehensiveHediffEffects). -->
+  <RimWorldAccess.Pawns.Health.Severity>Severity</RimWorldAccess.Pawns.Health.Severity>
+
   <!-- Needs. -->
   <RimWorldAccess.Pawns.Needs.NoTracker>{0}: No needs tracker</RimWorldAccess.Pawns.Needs.NoTracker>
   <RimWorldAccess.Pawns.Needs.Header>{0}'s Needs</RimWorldAccess.Pawns.Needs.Header>

--- a/Languages/Russian/Keyed/RimWorldAccess_Pawns.xml
+++ b/Languages/Russian/Keyed/RimWorldAccess_Pawns.xml
@@ -575,6 +575,7 @@
   <RimWorldAccess.Pawns.Health.NameHeader>{0}</RimWorldAccess.Pawns.Health.NameHeader>
   <RimWorldAccess.Pawns.Health.Capacity>{0}: {1}</RimWorldAccess.Pawns.Health.Capacity>
   <RimWorldAccess.Pawns.Health.PartHealth>{0}: {1}/{2}</RimWorldAccess.Pawns.Health.PartHealth>
+  <RimWorldAccess.Pawns.Health.Severity>Тяжесть</RimWorldAccess.Pawns.Health.Severity>
 
   <!-- Needs. -->
   <RimWorldAccess.Pawns.Needs.NoTracker>{0}: нет данных о нуждах</RimWorldAccess.Pawns.Needs.NoTracker>

--- a/Languages/SpanishLatin/Keyed/RimWorldAccess_Pawns.xml
+++ b/Languages/SpanishLatin/Keyed/RimWorldAccess_Pawns.xml
@@ -575,6 +575,7 @@
   <RimWorldAccess.Pawns.Health.NameHeader>{0}</RimWorldAccess.Pawns.Health.NameHeader>
   <RimWorldAccess.Pawns.Health.Capacity>{0}: {1}</RimWorldAccess.Pawns.Health.Capacity>
   <RimWorldAccess.Pawns.Health.PartHealth>{0}: {1}/{2}</RimWorldAccess.Pawns.Health.PartHealth>
+  <RimWorldAccess.Pawns.Health.Severity>Gravedad</RimWorldAccess.Pawns.Health.Severity>
 
   <!-- Needs. -->
   <RimWorldAccess.Pawns.Needs.NoTracker>{0}: Sin registro de necesidades</RimWorldAccess.Pawns.Needs.NoTracker>

--- a/Languages/Ukrainian/Keyed/RimWorldAccess_Pawns.xml
+++ b/Languages/Ukrainian/Keyed/RimWorldAccess_Pawns.xml
@@ -569,6 +569,7 @@
   <RimWorldAccess.Pawns.Health.NameHeader>{0}</RimWorldAccess.Pawns.Health.NameHeader>
   <RimWorldAccess.Pawns.Health.Capacity>{0}: {1}</RimWorldAccess.Pawns.Health.Capacity>
   <RimWorldAccess.Pawns.Health.PartHealth>{0}: {1}/{2}</RimWorldAccess.Pawns.Health.PartHealth>
+  <RimWorldAccess.Pawns.Health.Severity>Тяжкість</RimWorldAccess.Pawns.Health.Severity>
 
   <!-- Needs. -->
   <RimWorldAccess.Pawns.Needs.NoTracker>{0}: немає трекера потреб</RimWorldAccess.Pawns.Needs.NoTracker>

--- a/src/Inspection/InspectionTreeBuilder.cs
+++ b/src/Inspection/InspectionTreeBuilder.cs
@@ -3180,7 +3180,9 @@ namespace RimWorldAccess
                     hediffName += $" x{count}";
 
                 bool hasExpandableContent = !string.IsNullOrWhiteSpace(representative.TipStringExtra)
-                                         || !string.IsNullOrWhiteSpace(representative.Description);
+                                         || !string.IsNullOrWhiteSpace(representative.Description)
+                                         || !string.IsNullOrEmpty(representative.SeverityLabel)
+                                         || representative.TryGetComp<HediffComp_Immunizable>() != null;
 
                 var hediffItem = new InspectionTreeItem
                 {

--- a/src/Pawns/CLAUDE.md
+++ b/src/Pawns/CLAUDE.md
@@ -34,6 +34,13 @@ Pawn information, character tabs, policies, and assignments.
 ## Architecture
 PawnSelectionState integrates with scanner. ColonistBarState provides page-based bar navigation with Alt+Arrow/number keys, reordering via ColonistBar.Reorder(), and mech section after colonist pages. Quick info shortcuts (Alt+M/H/N) work without opening tabs. Full tabs navigate detailed character info.
 
+### HealthTabHelper.GetComprehensiveHediffEffects
+Builds the hediff detail children shown in the inspection tree's Health tab (consumed by `InspectionTreeBuilder.BuildHediffDetailChildren`). Beyond vanilla's `Hediff.TipStringExtra` (functional effects), it explicitly reads:
+- `Hediff.SeverityLabel` — vanilla only populates this for lethal/`alwaysShowSeverity` hediffs, and it's never part of `TipStringExtra`, so it's read directly and prefixed with the `RimWorldAccess.Pawns.Health.Severity` key.
+- `HediffComp_Immunizable.Immunity` — read directly rather than relying on the comp's own `CompTipStringExtra` (which vanilla suppresses once `Hidden`, not naturally-developable, or fully immune). Duplicate immunity lines from `TipStringExtra` are filtered out.
+
+Both were lost when PR #62 rewrote this method to rely solely on `TipStringExtra` (fixed for issue #81 — see git history on `HealthTabHelper.cs` around commit `335af70` for the original implementation this restores).
+
 ### PawnSkillsTableState
 - Global Alt+P opens a read-only 2D table: rows = colonists (colonist bar order), columns = Name + all SkillDefs (vanilla SkillUI order, `listOrder` descending)
 - Built on `TabularMenuHelper<Pawn>` (same pattern as WorkTableState). Cell value: `"[passion, ]{level}, {LevelDescriptor}"` or `"incapable"` for disabled skills

--- a/src/Pawns/HealthTabHelper.cs
+++ b/src/Pawns/HealthTabHelper.cs
@@ -356,7 +356,9 @@ namespace RimWorldAccess
 
         /// <summary>
         /// Gets comprehensive effect information for a hediff, focusing on functional impacts.
-        /// Uses vanilla's TipStringExtra for consistency with what sighted players see.
+        /// Uses vanilla's TipStringExtra for consistency with what sighted players see, plus
+        /// explicit severity and immunity readouts (see below) that TipStringExtra alone does
+        /// not reliably surface.
         /// </summary>
         public static string GetComprehensiveHediffEffects(Hediff hediff, Pawn pawn)
         {
@@ -371,11 +373,41 @@ namespace RimWorldAccess
                 sb.AppendLine("PawnsWithLifeThreateningDisease".Translate().ToString().ToUpper());
             }
 
+            // Severity - vanilla's own formatted severity string (e.g. "54%"). Vanilla only
+            // populates this for hediffs that can kill or that opt into always showing it
+            // (def.alwaysShowSeverity); it is never included in TipStringExtra, so it must be
+            // read directly. This was dropped by PR #62's TipStringExtra-only rewrite.
+            string severityLabel = hediff.SeverityLabel;
+            if (!string.IsNullOrEmpty(severityLabel))
+            {
+                sb.AppendLine($"{"RimWorldAccess.Pawns.Health.Severity".Translate()}: {severityLabel}");
+            }
+
+            // Immunity progress - read HediffComp_Immunizable directly rather than relying on
+            // TipStringExtra's indirect CompTipStringExtra aggregation, which vanilla hides once
+            // Hidden, not naturally-developable, or already fully immune. Also dropped by #62.
+            string immunityLabel = null;
+            var immunizable = hediff.TryGetComp<HediffComp_Immunizable>();
+            if (immunizable != null && pawn?.health?.immunity != null)
+            {
+                immunityLabel = $"{"Immunity".Translate()}: {immunizable.Immunity.ToStringPercent("0.#")}";
+                sb.AppendLine(immunityLabel);
+            }
+
             // Use vanilla's TipStringExtra - this is what sighted players see in tooltips
             string tipExtra = hediff.TipStringExtra;
             if (!string.IsNullOrEmpty(tipExtra))
             {
                 string cleaned = tipExtra.StripTags().Trim();
+                if (immunityLabel != null && !string.IsNullOrEmpty(cleaned))
+                {
+                    // Drop any redundant immunity line TipStringExtra may already contain -
+                    // we announced it explicitly above.
+                    string immunityKeyword = "Immunity".Translate();
+                    cleaned = string.Join("\n", cleaned
+                        .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                        .Where(line => !line.Contains(immunityKeyword)));
+                }
                 if (!string.IsNullOrEmpty(cleaned))
                 {
                     sb.AppendLine(cleaned);


### PR DESCRIPTION
PR #62 rewrote the hediff effects display to rely solely on vanilla's `Hediff.TipStringExtra`, which dropped the explicit severity and immunity readouts the mod used to show. `TipStringExtra` never carries the severity label, and only surfaces immunity indirectly through a comp method that vanilla itself suppresses in several cases (hidden, not naturally developable, or already fully immune).

Restored both explicitly: severity is read from `Hediff.SeverityLabel` when present, and immunity progress is read directly from `HediffComp_Immunizable` and announced as a percentage, filtering out any duplicate line `TipStringExtra` might still produce.

Closes #81