### PR TITLE
feat: add keyboard accessibility to the light/area color picker

### DIFF
--- a/Languages/ChineseSimplified/Keyed/RimWorldAccess_Building.xml
+++ b/Languages/ChineseSimplified/Keyed/RimWorldAccess_Building.xml
@@ -1035,4 +1035,18 @@
   <RimWorldAccess.Building.Plan.Desc.Rename>重命名此计划。</RimWorldAccess.Building.Plan.Desc.Rename>
   <RimWorldAccess.Building.Plan.Desc.ToggleVisibility>切换此计划在地图上的可见性。</RimWorldAccess.Building.Plan.Desc.ToggleVisibility>
   <RimWorldAccess.Building.Plan.Desc.Expand>通过绘制更多格来扩展此计划。</RimWorldAccess.Building.Plan.Desc.Expand>
+  <RimWorldAccess.Building.ColorPicker.Opened>颜色选择器已打开。当前颜色：{0}。之前颜色：{1}。共有{2}个预设色块，另有默认、色相和饱和度控件。上下箭头用于导航，聚焦时左右箭头调整色相或饱和度，Enter选择或应用，Escape取消。</RimWorldAccess.Building.ColorPicker.Opened>
+  <RimWorldAccess.Building.ColorPicker.HueSat>色相{0}度，饱和度{1}%</RimWorldAccess.Building.ColorPicker.HueSat>
+  <RimWorldAccess.Building.ColorPicker.White>白色</RimWorldAccess.Building.ColorPicker.White>
+  <RimWorldAccess.Building.ColorPicker.Selected>颜色已设置为{0}</RimWorldAccess.Building.ColorPicker.Selected>
+  <RimWorldAccess.Building.ColorPicker.DefaultOption>默认：{0}</RimWorldAccess.Building.ColorPicker.DefaultOption>
+  <RimWorldAccess.Building.ColorPicker.DarklightOption>暗光：{0}</RimWorldAccess.Building.ColorPicker.DarklightOption>
+  <RimWorldAccess.Building.ColorPicker.Darklight>暗光</RimWorldAccess.Building.ColorPicker.Darklight>
+  <RimWorldAccess.Building.ColorPicker.HueStepper>调整色相：{0}度。使用左右箭头更改。</RimWorldAccess.Building.ColorPicker.HueStepper>
+  <RimWorldAccess.Building.ColorPicker.HueChanged>色相：{0}度</RimWorldAccess.Building.ColorPicker.HueChanged>
+  <RimWorldAccess.Building.ColorPicker.SatStepper>调整饱和度：{0}%。使用左右箭头更改。</RimWorldAccess.Building.ColorPicker.SatStepper>
+  <RimWorldAccess.Building.ColorPicker.SatChanged>饱和度：{0}%</RimWorldAccess.Building.ColorPicker.SatChanged>
+  <RimWorldAccess.Building.ColorPicker.Accept>确认并应用颜色</RimWorldAccess.Building.ColorPicker.Accept>
+  <RimWorldAccess.Building.ColorPicker.Cancel>取消且不保存</RimWorldAccess.Building.ColorPicker.Cancel>
+  <RimWorldAccess.Building.ColorPicker.Accepted>颜色已应用：{0}</RimWorldAccess.Building.ColorPicker.Accepted>
 </LanguageData>

--- a/Languages/English/Keyed/RimWorldAccess_Building.xml
+++ b/Languages/English/Keyed/RimWorldAccess_Building.xml
@@ -1038,6 +1038,34 @@
   <RimWorldAccess.Building.PlanColor.Purple>Purple</RimWorldAccess.Building.PlanColor.Purple>
   <RimWorldAccess.Building.PlanColor.Pink>Pink</RimWorldAccess.Building.PlanColor.Pink>
 
+  <!-- Accessible color picker (src/Building/ColorPickerAccessibilityState.cs). Wraps vanilla's
+       Dialog_ColorPickerBase (the light "change color" gizmo's Dialog_GlowerColorPicker, and
+       Dialog_AllowedAreaColorPicker, which shares the identical mouse-only UI). Presents the 54
+       preset swatches plus Default/Darklight as a flat navigable list, and Hue/Saturation as
+       step-adjustable controls (brightness is fixed by the dialog itself). Fixes GitHub issue #57. -->
+  <!-- {0} = current color description, {1} = previous color description, {2} = swatch count. -->
+  <RimWorldAccess.Building.ColorPicker.Opened>Color picker opened. Current color: {0}. Previous color: {1}. {2} preset swatches, plus Default, hue, and saturation controls. Up and down arrows navigate, left and right arrows adjust hue or saturation when focused there, Enter selects or applies, Escape cancels.</RimWorldAccess.Building.ColorPicker.Opened>
+  <!-- {0} = hue degrees, {1} = saturation percent. -->
+  <RimWorldAccess.Building.ColorPicker.HueSat>Hue {0} degrees, saturation {1} percent</RimWorldAccess.Building.ColorPicker.HueSat>
+  <RimWorldAccess.Building.ColorPicker.White>White</RimWorldAccess.Building.ColorPicker.White>
+  <!-- {0} = color description. Spoken when Default/Darklight/a swatch is chosen with Enter. -->
+  <RimWorldAccess.Building.ColorPicker.Selected>Color set to {0}</RimWorldAccess.Building.ColorPicker.Selected>
+  <!-- {0} = color description, spoken while navigating onto the Default item. -->
+  <RimWorldAccess.Building.ColorPicker.DefaultOption>Default: {0}</RimWorldAccess.Building.ColorPicker.DefaultOption>
+  <!-- {0} = color description, spoken while navigating onto the Darklight item. -->
+  <RimWorldAccess.Building.ColorPicker.DarklightOption>Darklight: {0}</RimWorldAccess.Building.ColorPicker.DarklightOption>
+  <RimWorldAccess.Building.ColorPicker.Darklight>Darklight</RimWorldAccess.Building.ColorPicker.Darklight>
+  <!-- {0} = current hue in degrees, spoken while navigating onto or adjusting the hue stepper. -->
+  <RimWorldAccess.Building.ColorPicker.HueStepper>Adjust hue: {0} degrees. Use left and right arrow to change.</RimWorldAccess.Building.ColorPicker.HueStepper>
+  <RimWorldAccess.Building.ColorPicker.HueChanged>Hue: {0} degrees</RimWorldAccess.Building.ColorPicker.HueChanged>
+  <!-- {0} = current saturation percent, spoken while navigating onto or adjusting the saturation stepper. -->
+  <RimWorldAccess.Building.ColorPicker.SatStepper>Adjust saturation: {0} percent. Use left and right arrow to change.</RimWorldAccess.Building.ColorPicker.SatStepper>
+  <RimWorldAccess.Building.ColorPicker.SatChanged>Saturation: {0} percent</RimWorldAccess.Building.ColorPicker.SatChanged>
+  <RimWorldAccess.Building.ColorPicker.Accept>Accept and apply color</RimWorldAccess.Building.ColorPicker.Accept>
+  <RimWorldAccess.Building.ColorPicker.Cancel>Cancel without saving</RimWorldAccess.Building.ColorPicker.Cancel>
+  <!-- {0} = color description. Spoken when Accept is activated. -->
+  <RimWorldAccess.Building.ColorPicker.Accepted>Color applied: {0}</RimWorldAccess.Building.ColorPicker.Accepted>
+
   <!-- Plan management announcements (src/Building/PlanActionHelper.cs). -->
   <RimWorldAccess.Building.Plan.Hidden>Plan hidden</RimWorldAccess.Building.Plan.Hidden>
   <!-- {0} = plan name. -->

--- a/Languages/Russian/Keyed/RimWorldAccess_Building.xml
+++ b/Languages/Russian/Keyed/RimWorldAccess_Building.xml
@@ -1036,4 +1036,18 @@
   <RimWorldAccess.Building.Plan.Desc.Rename>Переименовать эту планировку.</RimWorldAccess.Building.Plan.Desc.Rename>
   <RimWorldAccess.Building.Plan.Desc.ToggleVisibility>Показать или скрыть эту планировку на карте.</RimWorldAccess.Building.Plan.Desc.ToggleVisibility>
   <RimWorldAccess.Building.Plan.Desc.Expand>Расширить эту планировку, добавив клетки.</RimWorldAccess.Building.Plan.Desc.Expand>
+  <RimWorldAccess.Building.ColorPicker.Opened>Открыт выбор цвета. Текущий цвет: {0}. Предыдущий цвет: {1}. {2} готовых образцов цвета, а также элементы управления «По умолчанию», оттенком и насыщенностью. Стрелки вверх и вниз для навигации, стрелки влево и вправо изменяют оттенок или насыщенность при фокусе на них, Enter выбирает или применяет, Escape отменяет.</RimWorldAccess.Building.ColorPicker.Opened>
+  <RimWorldAccess.Building.ColorPicker.HueSat>Оттенок {0} градусов, насыщенность {1} процентов</RimWorldAccess.Building.ColorPicker.HueSat>
+  <RimWorldAccess.Building.ColorPicker.White>Белый</RimWorldAccess.Building.ColorPicker.White>
+  <RimWorldAccess.Building.ColorPicker.Selected>Цвет установлен: {0}</RimWorldAccess.Building.ColorPicker.Selected>
+  <RimWorldAccess.Building.ColorPicker.DefaultOption>По умолчанию: {0}</RimWorldAccess.Building.ColorPicker.DefaultOption>
+  <RimWorldAccess.Building.ColorPicker.DarklightOption>Светящийся в темноте: {0}</RimWorldAccess.Building.ColorPicker.DarklightOption>
+  <RimWorldAccess.Building.ColorPicker.Darklight>Светящийся в темноте</RimWorldAccess.Building.ColorPicker.Darklight>
+  <RimWorldAccess.Building.ColorPicker.HueStepper>Настройка оттенка: {0} градусов. Используйте стрелки влево и вправо для изменения.</RimWorldAccess.Building.ColorPicker.HueStepper>
+  <RimWorldAccess.Building.ColorPicker.HueChanged>Оттенок: {0} градусов</RimWorldAccess.Building.ColorPicker.HueChanged>
+  <RimWorldAccess.Building.ColorPicker.SatStepper>Настройка насыщенности: {0} процентов. Используйте стрелки влево и вправо для изменения.</RimWorldAccess.Building.ColorPicker.SatStepper>
+  <RimWorldAccess.Building.ColorPicker.SatChanged>Насыщенность: {0} процентов</RimWorldAccess.Building.ColorPicker.SatChanged>
+  <RimWorldAccess.Building.ColorPicker.Accept>Принять и применить цвет</RimWorldAccess.Building.ColorPicker.Accept>
+  <RimWorldAccess.Building.ColorPicker.Cancel>Отменить без сохранения</RimWorldAccess.Building.ColorPicker.Cancel>
+  <RimWorldAccess.Building.ColorPicker.Accepted>Цвет применён: {0}</RimWorldAccess.Building.ColorPicker.Accepted>
 </LanguageData>

--- a/Languages/SpanishLatin/Keyed/RimWorldAccess_Building.xml
+++ b/Languages/SpanishLatin/Keyed/RimWorldAccess_Building.xml
@@ -1053,4 +1053,20 @@
   <RimWorldAccess.Building.Plan.Desc.Rename>Renombra esta planificación.</RimWorldAccess.Building.Plan.Desc.Rename>
   <RimWorldAccess.Building.Plan.Desc.ToggleVisibility>Alterna la visibilidad de esta planificación en el mapa.</RimWorldAccess.Building.Plan.Desc.ToggleVisibility>
   <RimWorldAccess.Building.Plan.Desc.Expand>Expande esta planificación dibujando más cuadros.</RimWorldAccess.Building.Plan.Desc.Expand>
+
+  <!-- Accessible color picker (src/Building/ColorPickerAccessibilityState.cs). -->
+  <RimWorldAccess.Building.ColorPicker.Opened>Selector de color abierto. Color actual: {0}. Color anterior: {1}. {2} muestras predefinidas, más los controles de Predeterminado, matiz y saturación. Las flechas arriba y abajo navegan, izquierda y derecha ajustan el matiz o la saturación cuando están enfocados, Enter selecciona o aplica, Escape cancela.</RimWorldAccess.Building.ColorPicker.Opened>
+  <RimWorldAccess.Building.ColorPicker.HueSat>Matiz {0} grados, saturación {1} por ciento</RimWorldAccess.Building.ColorPicker.HueSat>
+  <RimWorldAccess.Building.ColorPicker.White>Blanco</RimWorldAccess.Building.ColorPicker.White>
+  <RimWorldAccess.Building.ColorPicker.Selected>Color establecido a {0}</RimWorldAccess.Building.ColorPicker.Selected>
+  <RimWorldAccess.Building.ColorPicker.DefaultOption>Predeterminado: {0}</RimWorldAccess.Building.ColorPicker.DefaultOption>
+  <RimWorldAccess.Building.ColorPicker.DarklightOption>Oscuridad: {0}</RimWorldAccess.Building.ColorPicker.DarklightOption>
+  <RimWorldAccess.Building.ColorPicker.Darklight>Oscuridad</RimWorldAccess.Building.ColorPicker.Darklight>
+  <RimWorldAccess.Building.ColorPicker.HueStepper>Ajustar matiz: {0} grados. Usa las flechas izquierda y derecha para cambiar.</RimWorldAccess.Building.ColorPicker.HueStepper>
+  <RimWorldAccess.Building.ColorPicker.HueChanged>Matiz: {0} grados</RimWorldAccess.Building.ColorPicker.HueChanged>
+  <RimWorldAccess.Building.ColorPicker.SatStepper>Ajustar saturación: {0} por ciento. Usa las flechas izquierda y derecha para cambiar.</RimWorldAccess.Building.ColorPicker.SatStepper>
+  <RimWorldAccess.Building.ColorPicker.SatChanged>Saturación: {0} por ciento</RimWorldAccess.Building.ColorPicker.SatChanged>
+  <RimWorldAccess.Building.ColorPicker.Accept>Aceptar y aplicar color</RimWorldAccess.Building.ColorPicker.Accept>
+  <RimWorldAccess.Building.ColorPicker.Cancel>Cancelar sin guardar</RimWorldAccess.Building.ColorPicker.Cancel>
+  <RimWorldAccess.Building.ColorPicker.Accepted>Color aplicado: {0}</RimWorldAccess.Building.ColorPicker.Accepted>
 </LanguageData>

--- a/Languages/Ukrainian/Keyed/RimWorldAccess_Building.xml
+++ b/Languages/Ukrainian/Keyed/RimWorldAccess_Building.xml
@@ -1032,4 +1032,18 @@
   <RimWorldAccess.Building.Plan.Desc.Rename>Перейменувати цей маркер планування.</RimWorldAccess.Building.Plan.Desc.Rename>
   <RimWorldAccess.Building.Plan.Desc.ToggleVisibility>Перемкнути видимість цього маркера планування на мапі.</RimWorldAccess.Building.Plan.Desc.ToggleVisibility>
   <RimWorldAccess.Building.Plan.Desc.Expand>Розширити цей маркер планування, намалювавши більше клітинок.</RimWorldAccess.Building.Plan.Desc.Expand>
+  <RimWorldAccess.Building.ColorPicker.Opened>Відкрито вибір кольору. Поточний колір: {0}. Попередній колір: {1}. {2} готових зразків кольору, а також елементи керування «За замовчуванням», відтінком і насиченістю. Стрілки вгору і вниз для навігації, стрілки ліворуч і праворуч змінюють відтінок або насиченість, коли на них фокус, Enter вибирає або застосовує, Escape скасовує.</RimWorldAccess.Building.ColorPicker.Opened>
+  <RimWorldAccess.Building.ColorPicker.HueSat>Відтінок {0} градусів, насиченість {1} відсотків</RimWorldAccess.Building.ColorPicker.HueSat>
+  <RimWorldAccess.Building.ColorPicker.White>Білий</RimWorldAccess.Building.ColorPicker.White>
+  <RimWorldAccess.Building.ColorPicker.Selected>Колір встановлено: {0}</RimWorldAccess.Building.ColorPicker.Selected>
+  <RimWorldAccess.Building.ColorPicker.DefaultOption>За замовчуванням: {0}</RimWorldAccess.Building.ColorPicker.DefaultOption>
+  <RimWorldAccess.Building.ColorPicker.DarklightOption>Світіння в темряві: {0}</RimWorldAccess.Building.ColorPicker.DarklightOption>
+  <RimWorldAccess.Building.ColorPicker.Darklight>Світіння в темряві</RimWorldAccess.Building.ColorPicker.Darklight>
+  <RimWorldAccess.Building.ColorPicker.HueStepper>Налаштування відтінку: {0} градусів. Використовуйте стрілки ліворуч і праворуч для зміни.</RimWorldAccess.Building.ColorPicker.HueStepper>
+  <RimWorldAccess.Building.ColorPicker.HueChanged>Відтінок: {0} градусів</RimWorldAccess.Building.ColorPicker.HueChanged>
+  <RimWorldAccess.Building.ColorPicker.SatStepper>Налаштування насиченості: {0} відсотків. Використовуйте стрілки ліворуч і праворуч для зміни.</RimWorldAccess.Building.ColorPicker.SatStepper>
+  <RimWorldAccess.Building.ColorPicker.SatChanged>Насиченість: {0} відсотків</RimWorldAccess.Building.ColorPicker.SatChanged>
+  <RimWorldAccess.Building.ColorPicker.Accept>Прийняти й застосувати колір</RimWorldAccess.Building.ColorPicker.Accept>
+  <RimWorldAccess.Building.ColorPicker.Cancel>Скасувати без збереження</RimWorldAccess.Building.ColorPicker.Cancel>
+  <RimWorldAccess.Building.ColorPicker.Accepted>Колір застосовано: {0}</RimWorldAccess.Building.ColorPicker.Accepted>
 </LanguageData>

--- a/src/Building/CLAUDE.md
+++ b/src/Building/CLAUDE.md
@@ -33,6 +33,21 @@ self-contained).
 **Areas** - `AreaPatch.cs`, `AreaPaintingState.cs`, `WindowlessAreaState.cs`
 Allowed areas and home zone management.
 
+**Color Picker** - `ColorPickerAccessibilityState.cs`, `ColorPickerAccessibilityPatch.cs`
+Accessible replacement for vanilla's mouse-only `Dialog_ColorPickerBase` window (the light "change
+color" gizmo's `Dialog_GlowerColorPicker`, plus `Dialog_AllowedAreaColorPicker`, which shares the
+same UI). Unlike `PlanColorHelper`/`PaintColorHelper` (which intercept the designator/gizmo so the
+real dialog never opens), this leaves the real vanilla window in the WindowStack — same pattern as
+`SliderDialogState`/`SliderDialogPatch` for `Dialog_Slider` — and drives it entirely via reflection
+on `Dialog_ColorPickerBase`'s protected members (`color`, `PickableColors`, `DefaultColor`,
+`ShowDarklight`, `ForcedColorValue`, `SaveColor`). Presents Default, Darklight (if supported), and
+the 54 preset swatches as a flat navigable list (Up/Down), plus step-adjustable Hue/Saturation
+controls (Left/Right nudge in 15°/5% steps when focused there; brightness is fixed by the dialog
+itself so no Value control is needed). Enter applies the focused swatch/preset as the working color
+without closing (mirrors clicking a vanilla swatch) or activates Accept/Cancel. No
+`Window.OnCancelKeyPressed`/`OnAcceptKeyPressed` patch is needed — see the design notes on
+`ColorPickerAccessibilityState` for why. Wired in `UnifiedKeyboardPatch` at priority -0.212.
+
 **Analysis** - `ObstacleDetector.cs`, `EnclosureDetector.cs`
 Find obstacles blocking placement; detect rooms formed by blueprints.
 

--- a/src/Building/ColorPickerAccessibilityPatch.cs
+++ b/src/Building/ColorPickerAccessibilityPatch.cs
@@ -1,0 +1,46 @@
+using System;
+using HarmonyLib;
+using RimWorld;
+using Verse;
+
+namespace RimWorldAccess
+{
+    /// <summary>
+    /// Wires <see cref="ColorPickerAccessibilityState"/> into the lifecycle of every
+    /// <see cref="Dialog_ColorPickerBase"/> (the light "change color" gizmo's
+    /// <see cref="Dialog_GlowerColorPicker"/>, and <see cref="Dialog_AllowedAreaColorPicker"/>, which
+    /// shares the identical inaccessible mouse-only UI). No <c>OnCancelKeyPressed</c> or
+    /// <c>OnAcceptKeyPressed</c> patch is needed here — see the design notes on
+    /// <see cref="ColorPickerAccessibilityState"/> for why, mirroring <c>SliderDialogPatch</c>.
+    /// </summary>
+    public static class ColorPickerAccessibilityPatch
+    {
+        [HarmonyPatch(typeof(Window), "PostOpen")]
+        public static class Window_PostOpen_ColorPicker_Patch
+        {
+            [HarmonyPostfix]
+            public static void Postfix(Window __instance)
+            {
+                if (!(__instance is Dialog_ColorPickerBase picker)) return;
+                try { ColorPickerAccessibilityState.Open(picker); }
+                catch (Exception ex) { Log.Error($"[ColorPickerAccessibilityPatch] PostOpen failed: {ex.Message}"); }
+            }
+        }
+
+        [HarmonyPatch(typeof(Window), "PostClose")]
+        public static class Window_PostClose_ColorPicker_Patch
+        {
+            [HarmonyPostfix]
+            public static void Postfix(Window __instance)
+            {
+                if (!(__instance is Dialog_ColorPickerBase)) return;
+                try
+                {
+                    if (ColorPickerAccessibilityState.IsActive)
+                        ColorPickerAccessibilityState.Close();
+                }
+                catch (Exception ex) { Log.Error($"[ColorPickerAccessibilityPatch] PostClose failed: {ex.Message}"); }
+            }
+        }
+    }
+}

--- a/src/Building/ColorPickerAccessibilityState.cs
+++ b/src/Building/ColorPickerAccessibilityState.cs
@@ -1,0 +1,397 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace RimWorldAccess
+{
+    /// <summary>
+    /// Keyboard accessibility for vanilla's custom color-picker window
+    /// (<see cref="Dialog_ColorPickerBase"/> and its subclasses <see cref="Dialog_GlowerColorPicker"/>
+    /// — the "change color" gizmo on lights (<see cref="CompGlower"/>) — and
+    /// <see cref="Dialog_AllowedAreaColorPicker"/>). Fixes GitHub issue #57.
+    ///
+    /// Vanilla's picker is a fully mouse-driven immediate-mode window: an HSV color wheel you drag,
+    /// a "color temperature" bar you drag, a palette of 54 unlabeled swatches you click, and two
+    /// quick-select swatches (Default / Darklight). None of it has a keyboard equivalent, so a blind
+    /// user who opens the gizmo gets a modal dialog with no way to interact with it at all.
+    ///
+    /// Rather than trying to make the mouse-drag wheel keyboard-operable (a 2D continuous drag pad
+    /// has no natural keyboard mapping), this presents the exact same palette as a flat, ordered list
+    /// (Default, Darklight if supported, then each of the 54 preset swatches), plus two step-adjustable
+    /// Hue / Saturation controls that reach any color the wheel could (brightness is fixed by the
+    /// dialog itself via <c>ForcedColorValue</c> for both known subclasses, so no Value/brightness
+    /// control is needed). Up/Down move between items; Left/Right move between items too, EXCEPT
+    /// while focused on the Hue or Saturation stepper, where they nudge that value instead. Enter
+    /// applies the focused swatch/preset as the working color (mirrors clicking a vanilla swatch —
+    /// it does not close the dialog), or activates Accept/Cancel. Escape cancels.
+    ///
+    /// The real vanilla window is left in the WindowStack exactly like <see cref="SliderDialogState"/>
+    /// does for <c>Dialog_Slider</c> — we don't need to intercept <c>WindowStack.Add</c> at all here.
+    /// Every key we handle calls <c>Event.current.Use()</c> in <see cref="UnifiedKeyboardPatch"/>
+    /// before the vanilla window's own <c>DoWindowContents</c> runs later in the same
+    /// <c>UIRootOnGUI</c> call, so the mouse-only widgets underneath never see the keystroke.
+    /// Escape closing the dialog ourselves before vanilla's own
+    /// <c>KeyBindingDefOf.Cancel.KeyDownEvent &amp;&amp; IsOpen</c> check runs means that check sees
+    /// <c>IsOpen == false</c> and never calls <c>Window.OnCancelKeyPressed</c> a second time — no
+    /// <c>Window.OnCancelKeyPressed</c> patch is needed (unlike the CaravanFormation/QuantityMenu
+    /// stacking case in the root CLAUDE.md, there is no separate outer dialog left open underneath
+    /// us to be double-closed). Enter needs no <c>OnAcceptKeyPressed</c> patch either: the base
+    /// dialog's constructor sets <c>closeOnAccept = false</c>, so vanilla's default Accept handling
+    /// is already a no-op for this window.
+    /// </summary>
+    public static class ColorPickerAccessibilityState
+    {
+        private static readonly FieldInfo ColorField =
+            AccessTools.Field(typeof(Dialog_ColorPickerBase), "color");
+        private static readonly FieldInfo OldColorField =
+            AccessTools.Field(typeof(Dialog_ColorPickerBase), "oldColor");
+        private static readonly PropertyInfo PickableColorsProp =
+            AccessTools.Property(typeof(Dialog_ColorPickerBase), "PickableColors");
+        private static readonly PropertyInfo DefaultColorProp =
+            AccessTools.Property(typeof(Dialog_ColorPickerBase), "DefaultColor");
+        private static readonly PropertyInfo ShowDarklightProp =
+            AccessTools.Property(typeof(Dialog_ColorPickerBase), "ShowDarklight");
+        private static readonly PropertyInfo ForcedColorValueProp =
+            AccessTools.Property(typeof(Dialog_ColorPickerBase), "ForcedColorValue");
+        private static readonly MethodInfo SaveColorMethod =
+            AccessTools.Method(typeof(Dialog_ColorPickerBase), "SaveColor", new[] { typeof(Color) });
+
+        private const float HueStepDegrees = 15f;
+        private const float SatStepPercent = 0.05f;
+
+        private static bool isActive;
+        private static Dialog_ColorPickerBase currentDialog;
+        private static List<Color> palette = new List<Color>();
+        private static bool showDarklight;
+        private static float forcedValue;
+        private static int selectedIndex;
+
+        // Flat item layout, computed once at Open():
+        //   0                       -> Default
+        //   1 (only if showDarklight) -> Darklight
+        //   paletteStart..paletteStart+palette.Count-1 -> palette swatches
+        //   hueIndex                -> Hue stepper
+        //   satIndex                -> Saturation stepper
+        //   acceptIndex             -> Accept
+        //   cancelIndex             -> Cancel (== totalCount - 1)
+        private static int paletteStart;
+        private static int hueIndex;
+        private static int satIndex;
+        private static int acceptIndex;
+        private static int cancelIndex;
+        private static int totalCount;
+
+        public static bool IsActive => isActive;
+
+        public static void Open(Dialog_ColorPickerBase dialog)
+        {
+            if (dialog == null) return;
+            try
+            {
+                currentDialog = dialog;
+                palette = PickableColorsProp?.GetValue(dialog) as List<Color> ?? new List<Color>();
+                showDarklight = ShowDarklightProp != null && (bool)ShowDarklightProp.GetValue(dialog);
+                forcedValue = ForcedColorValueProp != null ? (float)ForcedColorValueProp.GetValue(dialog) : -1f;
+
+                paletteStart = 1 + (showDarklight ? 1 : 0);
+                hueIndex = paletteStart + palette.Count;
+                satIndex = hueIndex + 1;
+                acceptIndex = satIndex + 1;
+                cancelIndex = acceptIndex + 1;
+                totalCount = cancelIndex + 1;
+
+                selectedIndex = 0;
+                isActive = true;
+
+                Color current = GetColor();
+                Color old = OldColorField != null ? (Color)OldColorField.GetValue(dialog) : current;
+                string announcement = (string)"RimWorldAccess.Building.ColorPicker.Opened".Translate(
+                    DescribeColor(current), DescribeColor(old), palette.Count.ToString());
+                TolkHelper.SpeakData(announcement, SpeechPriority.High);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"[ColorPickerAccessibilityState] Open failed: {ex.Message}");
+                Close();
+            }
+        }
+
+        public static void Close()
+        {
+            isActive = false;
+            currentDialog = null;
+            palette = new List<Color>();
+            selectedIndex = 0;
+        }
+
+        public static bool HandleInput(Event evt)
+        {
+            if (!isActive || currentDialog == null) return false;
+            if (evt.type != EventType.KeyDown) return false;
+
+            KeyCode key = evt.keyCode;
+
+            if (key == KeyCode.Escape)
+            {
+                Cancel();
+                return true;
+            }
+
+            if (key == KeyCode.Return || key == KeyCode.KeypadEnter)
+            {
+                Activate();
+                return true;
+            }
+
+            if (key == KeyCode.UpArrow)
+            {
+                selectedIndex = MenuHelper.SelectPrevious(selectedIndex, totalCount);
+                AnnounceCurrent();
+                return true;
+            }
+            if (key == KeyCode.DownArrow)
+            {
+                selectedIndex = MenuHelper.SelectNext(selectedIndex, totalCount);
+                AnnounceCurrent();
+                return true;
+            }
+
+            if (key == KeyCode.LeftArrow)
+            {
+                if (selectedIndex == hueIndex) { AdjustHue(-HueStepDegrees); return true; }
+                if (selectedIndex == satIndex) { AdjustSaturation(-SatStepPercent); return true; }
+                selectedIndex = MenuHelper.SelectPrevious(selectedIndex, totalCount);
+                AnnounceCurrent();
+                return true;
+            }
+            if (key == KeyCode.RightArrow)
+            {
+                if (selectedIndex == hueIndex) { AdjustHue(HueStepDegrees); return true; }
+                if (selectedIndex == satIndex) { AdjustSaturation(SatStepPercent); return true; }
+                selectedIndex = MenuHelper.SelectNext(selectedIndex, totalCount);
+                AnnounceCurrent();
+                return true;
+            }
+
+            if (key == KeyCode.Home)
+            {
+                selectedIndex = 0;
+                AnnounceCurrent();
+                return true;
+            }
+            if (key == KeyCode.End)
+            {
+                selectedIndex = totalCount - 1;
+                AnnounceCurrent();
+                return true;
+            }
+
+            // Modal: consume any other key so it doesn't reach the vanilla widgets underneath.
+            return true;
+        }
+
+        private static void Activate()
+        {
+            if (selectedIndex == 0)
+            {
+                ActivateDefault();
+            }
+            else if (showDarklight && selectedIndex == 1)
+            {
+                ActivateDarklight();
+            }
+            else if (selectedIndex >= paletteStart && selectedIndex < paletteStart + palette.Count)
+            {
+                ActivateSwatch(selectedIndex - paletteStart);
+            }
+            else if (selectedIndex == hueIndex || selectedIndex == satIndex)
+            {
+                // Steppers apply live via Left/Right; Enter just re-reads the current value.
+                AnnounceCurrent();
+            }
+            else if (selectedIndex == acceptIndex)
+            {
+                Accept();
+            }
+            else if (selectedIndex == cancelIndex)
+            {
+                Cancel();
+            }
+        }
+
+        private static void ActivateDefault()
+        {
+            Color raw = DefaultColorProp != null ? (Color)DefaultColorProp.GetValue(currentDialog) : Color.white;
+            Color result = ApplyForcedValue(raw);
+            SetColor(result);
+            TolkHelper.SpeakData(
+                (string)"RimWorldAccess.Building.ColorPicker.Selected".Translate(DescribeColor(result)));
+        }
+
+        private static void ActivateDarklight()
+        {
+            // Matches vanilla: the Darklight quick-select swatch uses the raw preset unmodified
+            // (no ForcedColorValue adjustment), same as CompGlower's own Darklight toggle gizmo.
+            Color result = DarklightUtility.DefaultDarklight;
+            SetColor(result);
+            TolkHelper.SpeakData(
+                (string)"RimWorldAccess.Building.ColorPicker.Selected".Translate(
+                    "RimWorldAccess.Building.ColorPicker.Darklight".Translate()));
+        }
+
+        private static void ActivateSwatch(int paletteIndex)
+        {
+            if (paletteIndex < 0 || paletteIndex >= palette.Count) return;
+            Color result = palette[paletteIndex];
+            SetColor(result);
+            TolkHelper.SpeakData(
+                (string)"RimWorldAccess.Building.ColorPicker.Selected".Translate(DescribeColor(result)));
+        }
+
+        private static void AdjustHue(float deltaDegrees)
+        {
+            Color.RGBToHSV(GetColor(), out float h, out float s, out float v);
+            float newHue = Mathf.Repeat(h + deltaDegrees / 360f, 1f);
+            SetColor(BuildColor(newHue, s, v));
+            int hueDeg = Mathf.RoundToInt(newHue * 360f) % 360;
+            TolkHelper.SpeakData(
+                (string)"RimWorldAccess.Building.ColorPicker.HueChanged".Translate(hueDeg.ToString()),
+                SpeechPriority.Low);
+        }
+
+        private static void AdjustSaturation(float deltaFraction)
+        {
+            Color.RGBToHSV(GetColor(), out float h, out float s, out float v);
+            float newSat = Mathf.Clamp01(s + deltaFraction);
+            SetColor(BuildColor(h, newSat, v));
+            int satPct = Mathf.RoundToInt(newSat * 100f);
+            TolkHelper.SpeakData(
+                (string)"RimWorldAccess.Building.ColorPicker.SatChanged".Translate(satPct.ToString()),
+                SpeechPriority.Low);
+        }
+
+        private static Color BuildColor(float h, float s, float v)
+        {
+            float value = forcedValue >= 0f ? forcedValue : v;
+            Color c = Color.HSVToRGB(Mathf.Repeat(h, 1f), Mathf.Clamp01(s), value);
+            c.a = 1f;
+            return c;
+        }
+
+        private static Color ApplyForcedValue(Color raw)
+        {
+            if (forcedValue < 0f) return raw;
+            Color.RGBToHSV(raw, out float h, out float s, out _);
+            Color result = Color.HSVToRGB(h, s, forcedValue);
+            result.a = 1f;
+            return result;
+        }
+
+        private static void Accept()
+        {
+            try
+            {
+                Color final = GetColor();
+                SaveColorMethod?.Invoke(currentDialog, new object[] { final });
+                currentDialog?.Close(false);
+                string desc = DescribeColor(final);
+                Close();
+                TolkHelper.SpeakData(
+                    (string)"RimWorldAccess.Building.ColorPicker.Accepted".Translate(desc),
+                    SpeechPriority.High);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"[ColorPickerAccessibilityState] Accept failed: {ex}");
+                Close();
+            }
+        }
+
+        private static void Cancel()
+        {
+            currentDialog?.Close(false);
+            Close();
+            TolkHelper.Speak("RimWorldAccess.UI.Cancelled".Loc());
+        }
+
+        private static Color GetColor()
+        {
+            try { return (Color)(ColorField?.GetValue(currentDialog) ?? Color.white); }
+            catch { return Color.white; }
+        }
+
+        private static void SetColor(Color value)
+        {
+            try { ColorField?.SetValue(currentDialog, value); }
+            catch (Exception ex) { Log.Warning($"[ColorPickerAccessibilityState] SetColor failed: {ex.Message}"); }
+        }
+
+        private static void AnnounceCurrent()
+        {
+            // Default, Darklight, and palette swatches occupy the contiguous range [0, hueIndex),
+            // so selectedIndex is already the position within that range — hueIndex is the count.
+            if (selectedIndex == 0)
+            {
+                Color raw = DefaultColorProp != null ? (Color)DefaultColorProp.GetValue(currentDialog) : Color.white;
+                Color result = ApplyForcedValue(raw);
+                TolkHelper.SpeakData((string)"RimWorldAccess.Building.ColorPicker.DefaultOption".Translate(
+                    DescribeColor(result)) + " " + PositionSuffix(selectedIndex, hueIndex));
+            }
+            else if (showDarklight && selectedIndex == 1)
+            {
+                TolkHelper.SpeakData((string)"RimWorldAccess.Building.ColorPicker.DarklightOption".Translate(
+                    DescribeColor(DarklightUtility.DefaultDarklight)) + " " + PositionSuffix(selectedIndex, hueIndex));
+            }
+            else if (selectedIndex >= paletteStart && selectedIndex < paletteStart + palette.Count)
+            {
+                int paletteIndex = selectedIndex - paletteStart;
+                string desc = DescribeColor(palette[paletteIndex]);
+                string position = PositionSuffix(selectedIndex, hueIndex);
+                TolkHelper.SpeakData(desc + " " + position);
+            }
+            else if (selectedIndex == hueIndex)
+            {
+                Color.RGBToHSV(GetColor(), out float h, out _, out _);
+                int hueDeg = Mathf.RoundToInt(h * 360f) % 360;
+                TolkHelper.SpeakData(
+                    (string)"RimWorldAccess.Building.ColorPicker.HueStepper".Translate(hueDeg.ToString()));
+            }
+            else if (selectedIndex == satIndex)
+            {
+                Color.RGBToHSV(GetColor(), out _, out float s, out _);
+                int satPct = Mathf.RoundToInt(s * 100f);
+                TolkHelper.SpeakData(
+                    (string)"RimWorldAccess.Building.ColorPicker.SatStepper".Translate(satPct.ToString()));
+            }
+            else if (selectedIndex == acceptIndex)
+            {
+                TolkHelper.Speak("RimWorldAccess.Building.ColorPicker.Accept".Loc());
+            }
+            else if (selectedIndex == cancelIndex)
+            {
+                TolkHelper.Speak("RimWorldAccess.Building.ColorPicker.Cancel".Loc());
+            }
+        }
+
+        private static string PositionSuffix(int index, int count) => MenuHelper.FormatPosition(index, count);
+
+        /// <summary>
+        /// Describes a color by its hue/saturation (brightness is fixed by the dialog, so it carries
+        /// no distinguishing information). Near-zero saturation is reported as "White" instead of a
+        /// meaningless hue angle, matching how the achromatic first palette entry actually renders.
+        /// </summary>
+        private static string DescribeColor(Color c)
+        {
+            Color.RGBToHSV(c, out float h, out float s, out _);
+            if (s < 0.02f)
+                return "RimWorldAccess.Building.ColorPicker.White".Translate();
+            int hueDeg = Mathf.RoundToInt(h * 360f) % 360;
+            int satPct = Mathf.RoundToInt(s * 100f);
+            return (string)"RimWorldAccess.Building.ColorPicker.HueSat".Translate(hueDeg.ToString(), satPct.ToString());
+        }
+    }
+}

--- a/src/Building/ColorPickerAccessibilityState.cs
+++ b/src/Building/ColorPickerAccessibilityState.cs
@@ -179,13 +179,13 @@ namespace RimWorldAccess
 
             if (key == KeyCode.Home)
             {
-                selectedIndex = 0;
+                selectedIndex = MenuHelper.JumpToFirst();
                 AnnounceCurrent();
                 return true;
             }
             if (key == KeyCode.End)
             {
-                selectedIndex = totalCount - 1;
+                selectedIndex = MenuHelper.JumpToLast(totalCount);
                 AnnounceCurrent();
                 return true;
             }
@@ -332,55 +332,67 @@ namespace RimWorldAccess
 
         private static void AnnounceCurrent()
         {
-            // Default, Darklight, and palette swatches occupy the contiguous range [0, hueIndex),
-            // so selectedIndex is already the position within that range — hueIndex is the count.
+            // Up/Down walk one flat list of totalCount items — the swatches and the four controls
+            // alike — so every item reports its position against that same total. Positioning the
+            // swatches against their own sub-count instead would leave a user who hears the last
+            // swatch ("54 of 54") surprised that four more items follow.
+            string baseText;
+
             if (selectedIndex == 0)
             {
                 Color raw = DefaultColorProp != null ? (Color)DefaultColorProp.GetValue(currentDialog) : Color.white;
                 Color result = ApplyForcedValue(raw);
-                string baseText = (string)"RimWorldAccess.Building.ColorPicker.DefaultOption".Translate(DescribeColor(result));
-                TolkHelper.SpeakData(WithPosition(baseText, selectedIndex, hueIndex));
+                baseText = (string)"RimWorldAccess.Building.ColorPicker.DefaultOption".Translate(DescribeColor(result));
             }
             else if (showDarklight && selectedIndex == 1)
             {
-                string baseText = (string)"RimWorldAccess.Building.ColorPicker.DarklightOption".Translate(
+                baseText = (string)"RimWorldAccess.Building.ColorPicker.DarklightOption".Translate(
                     DescribeColor(DarklightUtility.DefaultDarklight));
-                TolkHelper.SpeakData(WithPosition(baseText, selectedIndex, hueIndex));
             }
             else if (selectedIndex >= paletteStart && selectedIndex < paletteStart + palette.Count)
             {
-                int paletteIndex = selectedIndex - paletteStart;
-                string baseText = DescribeColor(palette[paletteIndex]);
-                TolkHelper.SpeakData(WithPosition(baseText, selectedIndex, hueIndex));
+                baseText = DescribeColor(palette[selectedIndex - paletteStart]);
             }
             else if (selectedIndex == hueIndex)
             {
                 Color.RGBToHSV(GetColor(), out float h, out _, out _);
                 int hueDeg = Mathf.RoundToInt(h * 360f) % 360;
-                TolkHelper.SpeakData(
-                    (string)"RimWorldAccess.Building.ColorPicker.HueStepper".Translate(hueDeg.ToString()));
+                baseText = (string)"RimWorldAccess.Building.ColorPicker.HueStepper".Translate(hueDeg.ToString());
             }
             else if (selectedIndex == satIndex)
             {
                 Color.RGBToHSV(GetColor(), out _, out float s, out _);
                 int satPct = Mathf.RoundToInt(s * 100f);
-                TolkHelper.SpeakData(
-                    (string)"RimWorldAccess.Building.ColorPicker.SatStepper".Translate(satPct.ToString()));
+                baseText = (string)"RimWorldAccess.Building.ColorPicker.SatStepper".Translate(satPct.ToString());
             }
             else if (selectedIndex == acceptIndex)
             {
-                TolkHelper.Speak("RimWorldAccess.Building.ColorPicker.Accept".Loc());
+                baseText = "RimWorldAccess.Building.ColorPicker.Accept".Loc().ToString();
             }
             else if (selectedIndex == cancelIndex)
             {
-                TolkHelper.Speak("RimWorldAccess.Building.ColorPicker.Cancel".Loc());
+                baseText = "RimWorldAccess.Building.ColorPicker.Cancel".Loc().ToString();
             }
+            else
+            {
+                return;
+            }
+
+            TolkHelper.SpeakData(WithPosition(baseText, selectedIndex, totalCount));
         }
 
         private static string WithPosition(string baseText, int index, int count)
         {
             string position = MenuHelper.FormatPosition(index, count);
-            return string.IsNullOrEmpty(position) ? baseText : $"{baseText}. {position}";
+            if (string.IsNullOrEmpty(position))
+                return baseText;
+
+            // The stepper strings end in a period of their own; adding another before the
+            // position leaves a ".." for the screen reader to stumble over.
+            string trimmed = (baseText ?? "").TrimEnd();
+            return trimmed.EndsWith(".")
+                ? $"{trimmed} {position}"
+                : $"{trimmed}. {position}";
         }
 
         /// <summary>

--- a/src/Building/ColorPickerAccessibilityState.cs
+++ b/src/Building/ColorPickerAccessibilityState.cs
@@ -338,20 +338,20 @@ namespace RimWorldAccess
             {
                 Color raw = DefaultColorProp != null ? (Color)DefaultColorProp.GetValue(currentDialog) : Color.white;
                 Color result = ApplyForcedValue(raw);
-                TolkHelper.SpeakData((string)"RimWorldAccess.Building.ColorPicker.DefaultOption".Translate(
-                    DescribeColor(result)) + " " + PositionSuffix(selectedIndex, hueIndex));
+                string baseText = (string)"RimWorldAccess.Building.ColorPicker.DefaultOption".Translate(DescribeColor(result));
+                TolkHelper.SpeakData(WithPosition(baseText, selectedIndex, hueIndex));
             }
             else if (showDarklight && selectedIndex == 1)
             {
-                TolkHelper.SpeakData((string)"RimWorldAccess.Building.ColorPicker.DarklightOption".Translate(
-                    DescribeColor(DarklightUtility.DefaultDarklight)) + " " + PositionSuffix(selectedIndex, hueIndex));
+                string baseText = (string)"RimWorldAccess.Building.ColorPicker.DarklightOption".Translate(
+                    DescribeColor(DarklightUtility.DefaultDarklight));
+                TolkHelper.SpeakData(WithPosition(baseText, selectedIndex, hueIndex));
             }
             else if (selectedIndex >= paletteStart && selectedIndex < paletteStart + palette.Count)
             {
                 int paletteIndex = selectedIndex - paletteStart;
-                string desc = DescribeColor(palette[paletteIndex]);
-                string position = PositionSuffix(selectedIndex, hueIndex);
-                TolkHelper.SpeakData(desc + " " + position);
+                string baseText = DescribeColor(palette[paletteIndex]);
+                TolkHelper.SpeakData(WithPosition(baseText, selectedIndex, hueIndex));
             }
             else if (selectedIndex == hueIndex)
             {
@@ -377,7 +377,11 @@ namespace RimWorldAccess
             }
         }
 
-        private static string PositionSuffix(int index, int count) => MenuHelper.FormatPosition(index, count);
+        private static string WithPosition(string baseText, int index, int count)
+        {
+            string position = MenuHelper.FormatPosition(index, count);
+            return string.IsNullOrEmpty(position) ? baseText : $"{baseText}. {position}";
+        }
 
         /// <summary>
         /// Describes a color by its hue/saturation (brightness is fixed by the dialog, so it carries

--- a/src/Input/UnifiedKeyboardPatch.cs
+++ b/src/Input/UnifiedKeyboardPatch.cs
@@ -824,6 +824,20 @@ namespace RimWorldAccess
                 }
             }
 
+            // ===== PRIORITY -0.212: Handle accessible color picker (light/area) dialog if active =====
+            // Dialog_ColorPickerBase (Dialog_GlowerColorPicker / Dialog_AllowedAreaColorPicker) is a
+            // modal, mouse-only vanilla window left in the real WindowStack (see
+            // ColorPickerAccessibilityState / ColorPickerAccessibilityPatch in Building/, mirroring
+            // SliderDialogState). Must be near the top so it absorbs input before anything below.
+            if (ColorPickerAccessibilityState.IsActive)
+            {
+                if (ColorPickerAccessibilityState.HandleInput(Event.current))
+                {
+                    Event.current.Use();
+                    return;
+                }
+            }
+
             // ===== PRIORITY -0.21: Handle Anomaly Settings dialog if active =====
             // Modal dialog opened from the storyteller selection page (Tab → Anomaly Settings → Enter).
             // MUST be near the top of the routing chain because absorbInputAroundWindow modals


### PR DESCRIPTION
The color picker opened from a light's "change color" gizmo (also shared by the allowed-area color picker) is a mouse-only HSV wheel plus a grid of unlabeled swatches, completely inaccessible to screen reader users.

Rather than trying to make the mouse-drag wheel keyboard-operable, this presents the same palette as a flat navigable list (Default, Darklight, then the 54 preset swatches), plus step-adjustable Hue/Saturation controls that reach any color the wheel could. Up/Down move between items, Left/Right nudge Hue/Saturation when focused there (or move between items otherwise), Enter applies the focused color, Escape cancels. The real vanilla window stays in the window stack, same pattern already used for the slider dialog.

Tested live with a screen reader — navigation, color selection, and applying the color to an actual light all worked as expected.

Closes #57