### PR TITLE
feat(royalty): announce noble room requirements in room stats

### DIFF
--- a/Languages/ChineseSimplified/Keyed/RimWorldAccess_Map.xml
+++ b/Languages/ChineseSimplified/Keyed/RimWorldAccess_Map.xml
@@ -662,4 +662,9 @@
   <RimWorldAccess.Map.Tile.PaintSuffix>, {0}</RimWorldAccess.Map.Tile.PaintSuffix>
   <RimWorldAccess.Map.Tile.Plan>{0}{1}</RimWorldAccess.Map.Tile.Plan>
   <RimWorldAccess.Map.Scanner.CatName.Plans>计划</RimWorldAccess.Map.Scanner.CatName.Plans>
+  <RimWorldAccess.Map.Tile.Room.Req.ThroneHeader>{0}的王座厅，{1}</RimWorldAccess.Map.Tile.Room.Req.ThroneHeader>
+  <RimWorldAccess.Map.Tile.Room.Req.BedroomHeader>{0}的卧室，{1}</RimWorldAccess.Map.Tile.Room.Req.BedroomHeader>
+  <RimWorldAccess.Map.Tile.Room.Req.AllMet>所有要求已满足</RimWorldAccess.Map.Tile.Room.Req.AllMet>
+  <RimWorldAccess.Map.Tile.Room.Req.Summary>已满足{0}/{1}项要求</RimWorldAccess.Map.Tile.Room.Req.Summary>
+  <RimWorldAccess.Map.Tile.Room.Req.Missing>缺少：{0}</RimWorldAccess.Map.Tile.Room.Req.Missing>
 </LanguageData>

--- a/Languages/English/Keyed/RimWorldAccess_Map.xml
+++ b/Languages/English/Keyed/RimWorldAccess_Map.xml
@@ -600,6 +600,20 @@
   <RimWorldAccess.Map.Tile.Room.StatWithStage>{0}{1}: {2} ({3})</RimWorldAccess.Map.Tile.Room.StatWithStage>
   <RimWorldAccess.Map.Tile.Room.Stat>{0}{1}: {2}</RimWorldAccess.Map.Tile.Room.Stat>
 
+  <!-- Royal title room requirements (Royalty DLC). Appended to the room-stats readout when a
+       room serves a titled noble: the throne room of the noble a throne is assigned to, or the
+       bedroom of a titled owner. Each requirement label comes from the game and already includes
+       its progress (e.g. "Brazier 0 / 2"); the count and missing list are checked with the game's
+       own tests, so the readout matches the throne's requirement checklist a sighted player sees.
+       {0} = noble's name, {1} = title label. -->
+  <RimWorldAccess.Map.Tile.Room.Req.ThroneHeader>Throne room for {0}, {1}</RimWorldAccess.Map.Tile.Room.Req.ThroneHeader>
+  <RimWorldAccess.Map.Tile.Room.Req.BedroomHeader>Bedroom for {0}, {1}</RimWorldAccess.Map.Tile.Room.Req.BedroomHeader>
+  <RimWorldAccess.Map.Tile.Room.Req.AllMet>all requirements met</RimWorldAccess.Map.Tile.Room.Req.AllMet>
+  <!-- {0} = met count, {1} = total count. -->
+  <RimWorldAccess.Map.Tile.Room.Req.Summary>{0} of {1} requirements met</RimWorldAccess.Map.Tile.Room.Req.Summary>
+  <!-- {0} = semicolon-separated list of unmet requirement labels. -->
+  <RimWorldAccess.Map.Tile.Room.Req.Missing>missing: {0}</RimWorldAccess.Map.Tile.Room.Req.Missing>
+
   <!-- Temperature control building info (used in tile summary and
        in the light/temp hotkey). -->
   <RimWorldAccess.Map.Tile.TempControl.Cooler>cooling {0}, heating {1}</RimWorldAccess.Map.Tile.TempControl.Cooler>

--- a/Languages/Russian/Keyed/RimWorldAccess_Map.xml
+++ b/Languages/Russian/Keyed/RimWorldAccess_Map.xml
@@ -663,4 +663,9 @@
   <RimWorldAccess.Map.Tile.PaintSuffix>, {0}</RimWorldAccess.Map.Tile.PaintSuffix>
   <RimWorldAccess.Map.Tile.Plan>{0}: {1}</RimWorldAccess.Map.Tile.Plan>
   <RimWorldAccess.Map.Scanner.CatName.Plans>Планировки</RimWorldAccess.Map.Scanner.CatName.Plans>
+  <RimWorldAccess.Map.Tile.Room.Req.ThroneHeader>Тронный зал для {0}, {1}</RimWorldAccess.Map.Tile.Room.Req.ThroneHeader>
+  <RimWorldAccess.Map.Tile.Room.Req.BedroomHeader>Спальня для {0}, {1}</RimWorldAccess.Map.Tile.Room.Req.BedroomHeader>
+  <RimWorldAccess.Map.Tile.Room.Req.AllMet>все требования соблюдены</RimWorldAccess.Map.Tile.Room.Req.AllMet>
+  <RimWorldAccess.Map.Tile.Room.Req.Summary>выполнено {0} из {1} требований</RimWorldAccess.Map.Tile.Room.Req.Summary>
+  <RimWorldAccess.Map.Tile.Room.Req.Missing>не хватает: {0}</RimWorldAccess.Map.Tile.Room.Req.Missing>
 </LanguageData>

--- a/Languages/SpanishLatin/Keyed/RimWorldAccess_Map.xml
+++ b/Languages/SpanishLatin/Keyed/RimWorldAccess_Map.xml
@@ -600,6 +600,21 @@
   <RimWorldAccess.Map.Tile.Room.StatWithStage>{0}{1}: {2} ({3})</RimWorldAccess.Map.Tile.Room.StatWithStage>
   <RimWorldAccess.Map.Tile.Room.Stat>{0}{1}: {2}</RimWorldAccess.Map.Tile.Room.Stat>
 
+  <!-- Requisitos de sala por título real (DLC Royalty). Se agregan al informe de estadísticas
+       de la sala cuando esta pertenece a un noble con título: la sala del trono del noble al que
+       está asignado un trono, o el dormitorio de un propietario con título. La etiqueta de cada
+       requisito viene del juego e incluye su progreso (por ejemplo, "Brasero 0 / 2"); el recuento
+       y la lista de faltantes se verifican con las pruebas del propio juego, así que el informe
+       coincide con la lista de requisitos del trono que ve un jugador vidente.
+       {0} = nombre del noble, {1} = etiqueta del título. -->
+  <RimWorldAccess.Map.Tile.Room.Req.ThroneHeader>Sala del trono de {0}, {1}</RimWorldAccess.Map.Tile.Room.Req.ThroneHeader>
+  <RimWorldAccess.Map.Tile.Room.Req.BedroomHeader>Dormitorio de {0}, {1}</RimWorldAccess.Map.Tile.Room.Req.BedroomHeader>
+  <RimWorldAccess.Map.Tile.Room.Req.AllMet>todos los requisitos cumplidos</RimWorldAccess.Map.Tile.Room.Req.AllMet>
+  <!-- {0} = requisitos cumplidos, {1} = requisitos totales. -->
+  <RimWorldAccess.Map.Tile.Room.Req.Summary>{0} de {1} requisitos cumplidos</RimWorldAccess.Map.Tile.Room.Req.Summary>
+  <!-- {0} = lista de requisitos no cumplidos separada por punto y coma. -->
+  <RimWorldAccess.Map.Tile.Room.Req.Missing>faltan: {0}</RimWorldAccess.Map.Tile.Room.Req.Missing>
+
   <!-- Temperature control building info (used in tile summary and
        in the light/temp hotkey). -->
   <RimWorldAccess.Map.Tile.TempControl.Cooler>enfría al {0}, calienta al {1}</RimWorldAccess.Map.Tile.TempControl.Cooler>

--- a/Languages/Ukrainian/Keyed/RimWorldAccess_Map.xml
+++ b/Languages/Ukrainian/Keyed/RimWorldAccess_Map.xml
@@ -658,4 +658,9 @@
   <RimWorldAccess.Map.Tile.PaintSuffix>, {0}</RimWorldAccess.Map.Tile.PaintSuffix>
   <RimWorldAccess.Map.Tile.Plan>{0}, {1}</RimWorldAccess.Map.Tile.Plan>
   <RimWorldAccess.Map.Scanner.CatName.Plans>Плани</RimWorldAccess.Map.Scanner.CatName.Plans>
+  <RimWorldAccess.Map.Tile.Room.Req.ThroneHeader>Тронна зала для {0}, {1}</RimWorldAccess.Map.Tile.Room.Req.ThroneHeader>
+  <RimWorldAccess.Map.Tile.Room.Req.BedroomHeader>Спальня для {0}, {1}</RimWorldAccess.Map.Tile.Room.Req.BedroomHeader>
+  <RimWorldAccess.Map.Tile.Room.Req.AllMet>усі вимоги виконано</RimWorldAccess.Map.Tile.Room.Req.AllMet>
+  <RimWorldAccess.Map.Tile.Room.Req.Summary>виконано {0} з {1} вимог</RimWorldAccess.Map.Tile.Room.Req.Summary>
+  <RimWorldAccess.Map.Tile.Room.Req.Missing>бракує: {0}</RimWorldAccess.Map.Tile.Room.Req.Missing>
 </LanguageData>

--- a/src/Map/RoomRequirementsHelper.cs
+++ b/src/Map/RoomRequirementsHelper.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using System.Linq;
+using RimWorld;
+using Verse;
+
+namespace RimWorldAccess
+{
+    /// <summary>
+    /// Reports a Royalty noble's throne-room / bedroom title requirements for a room, with a
+    /// met / missing status for each one. Surfaces the same information a sighted player reads
+    /// off the throne's requirement checklist, which is otherwise invisible to a screen reader.
+    ///
+    /// The requirements come straight from the game: <see cref="RoomRequirement.LabelCap"/>
+    /// already produces a localized label that includes the numeric progress (e.g. "Brazier
+    /// 0 / 2", "Room size: 84 / 24 cells"), and <see cref="RoomRequirement.Met"/> is the game's
+    /// own test, so the readout always matches what the game itself considers satisfied. We only
+    /// add the localized framing around that list.
+    ///
+    /// Which title's requirements apply is decided by the game too:
+    /// <c>HighestTitleWithThroneRoomRequirements</c> / <c>HighestTitleWithBedroomRequirements</c>
+    /// return the title whose requirements are in effect (and null when the noble's title carries
+    /// none, e.g. Freeholder or Yeoman), so those rooms produce no readout at all.
+    ///
+    /// All of these are first-party RimWorld types compiled into the base assembly, so they are
+    /// referenced directly; the whole feature is gated on <see cref="ModsConfig.RoyaltyActive"/>
+    /// so it stays inert when the Royalty DLC is not installed.
+    /// </summary>
+    public static class RoomRequirementsHelper
+    {
+        /// <summary>
+        /// Returns a localized met / missing summary of the title requirements that apply to
+        /// <paramref name="room"/>, or null when none do (no Royalty DLC, not a proper room, or
+        /// no titled noble whose throne or bed is here). Appended to the room-stats readout.
+        /// </summary>
+        public static string GetTitleRequirementsInfo(Room room)
+        {
+            if (!ModsConfig.RoyaltyActive)
+                return null;
+
+            if (room == null || !room.ProperRoom)
+                return null;
+
+            var builder = new AnnouncementBuilder().DefaultSep(Separator.Period);
+
+            AppendThroneRequirements(room, builder);
+            AppendBedroomRequirements(room, builder);
+
+            string result = builder.Build();
+            return string.IsNullOrEmpty(result) ? null : result;
+        }
+
+        /// <summary>
+        /// If a throne in the room is assigned to a noble whose title has throne-room
+        /// requirements, appends that noble's requirement summary.
+        /// </summary>
+        private static void AppendThroneRequirements(Room room, AnnouncementBuilder builder)
+        {
+            foreach (Thing thing in room.ContainedAndAdjacentThings)
+            {
+                if (!(thing is Building_Throne throne) || throne.GetRoom() != room)
+                    continue;
+
+                Pawn noble = throne.AssignedPawn;
+                if (noble?.royalty == null)
+                    continue;
+
+                RoyalTitle title = noble.royalty.HighestTitleWithThroneRoomRequirements();
+                if (title?.def?.throneRoomRequirements == null)
+                    continue;
+
+                AppendRequirementBlock(
+                    "RimWorldAccess.Map.Tile.Room.Req.ThroneHeader",
+                    noble, title, title.def.throneRoomRequirements, room, builder);
+                return;
+            }
+        }
+
+        /// <summary>
+        /// If an owner of a bed in the room holds a title with bedroom requirements, appends
+        /// that owner's requirement summary.
+        /// </summary>
+        private static void AppendBedroomRequirements(Room room, AnnouncementBuilder builder)
+        {
+            foreach (Pawn owner in room.Owners)
+            {
+                if (owner?.royalty == null)
+                    continue;
+
+                RoyalTitle title = owner.royalty.HighestTitleWithBedroomRequirements();
+                if (title?.def?.bedroomRequirements == null)
+                    continue;
+
+                AppendRequirementBlock(
+                    "RimWorldAccess.Map.Tile.Room.Req.BedroomHeader",
+                    owner, title, title.def.bedroomRequirements, room, builder);
+                return;
+            }
+        }
+
+        /// <summary>
+        /// Builds one requirement block: a header naming the noble and title, then either
+        /// "all requirements met" or a met count followed by the list of missing requirements.
+        /// Precept-disabled requirements are skipped entirely, matching the game's own display.
+        /// </summary>
+        private static void AppendRequirementBlock(string headerKey, Pawn pawn, RoyalTitle title,
+            List<RoomRequirement> requirements, Room room, AnnouncementBuilder builder)
+        {
+            string titleLabel = title.def.GetLabelCapFor(pawn);
+            builder.Add(headerKey.Translate(pawn.LabelShortCap, titleLabel));
+
+            int total = 0;
+            int met = 0;
+            var missing = new List<string>();
+
+            foreach (RoomRequirement req in requirements)
+            {
+                if (req.Disabled(room, pawn))
+                    continue;
+
+                total++;
+                if (req.Met(room, pawn))
+                    met++;
+                else
+                    missing.Add(req.LabelCap(room));
+            }
+
+            if (total == 0)
+                return;
+
+            if (missing.Count == 0)
+            {
+                builder.Add("RimWorldAccess.Map.Tile.Room.Req.AllMet".Translate());
+                return;
+            }
+
+            builder.Add("RimWorldAccess.Map.Tile.Room.Req.Summary".Translate(met, total));
+            builder.Add("RimWorldAccess.Map.Tile.Room.Req.Missing".Translate(string.Join("; ", missing)));
+        }
+    }
+}

--- a/src/Map/TileInfoHelper.cs
+++ b/src/Map/TileInfoHelper.cs
@@ -593,6 +593,13 @@ namespace RimWorldAccess
                     AppendStat(statDef);
             }
 
+            // Royalty: if this room serves a titled noble (a throne assigned to them, or a bed
+            // they own), append the met/missing breakdown of their title's room requirements —
+            // the throne checklist a sighted player sees but a screen reader otherwise can't.
+            string titleRequirements = RoomRequirementsHelper.GetTitleRequirementsInfo(room);
+            if (!string.IsNullOrEmpty(titleRequirements))
+                builder.Add(titleRequirements, Separator.Period);
+
             return builder.Build();
         }
 


### PR DESCRIPTION
Closes #127

### What this does

Adds the throne-room / bedroom title requirements to the room-stats readout (key 5 and the room-stats gizmo). When a room serves a titled noble, the readout now ends with a met/missing summary:

> Bedroom for Mila, Acolyte. 4 of 5 requirements met. Missing: Double bed 0/1.

- **Throne room**: found via a `Building_Throne` assigned to a noble in the room.
- **Bedroom**: found via a titled owner of a bed in the room.
- Which title's requirements apply is decided by the game (`HighestTitleWithThroneRoomRequirements` / `…BedroomRequirements`), so a noble whose title has no requirements (Freeholder, Yeoman) produces no readout.

### How it stays consistent with the game

Each requirement's label and status come straight from vanilla: `RoomRequirement.LabelCap(room)` (which already bakes in the numeric progress, e.g. "Brazier 0/2", "Room size: 84/24 cells") and `RoomRequirement.Met(room, pawn)`. Precept-disabled requirements are skipped, matching the game's own display. It only lists what's missing plus a met count, to keep the readout short.

These are first-party types compiled into the base assembly, so they're referenced directly (no reflection); the whole feature is gated on `ModsConfig.RoyaltyActive` and is inert without the DLC.

### Changes

- New `src/Map/RoomRequirementsHelper.cs` → `GetTitleRequirementsInfo(Room)`.
- Wired into `TileInfoHelper.GetRoomStatsInfo(Room)` (the shared key-5 + gizmo path).
- New `RimWorldAccess.Map.Tile.Room.Req.*` strings in English and Spanish (Latin American).

### Testing

Tested in-game: built a throne room / bedroom for a titled colonist and confirmed key 5 announces the correct met count and the missing requirements, with labels matching the throne's visual checklist.